### PR TITLE
Add preview-template plugin that extracts to components

### DIFF
--- a/packages/@docfy/ember/dummy-docs/packages/ember/index.md
+++ b/packages/@docfy/ember/dummy-docs/packages/ember/index.md
@@ -1,3 +1,22 @@
 # Working with Ember
 
 This is a simple markdown
+
+
+Where are a lot of cool features here. One of them is to preview a template.
+
+```hbs preview-template
+<DocfyLink @to="/" class="text-blue-700">This is a link to index</DocfyLink>
+
+<div class="p-4 my-2 border border-blue-500 rounded">
+  I can have any hbs here and I can use any component avaliable in the host app.
+</div>
+```
+
+## Another content
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+
+```hbs preview-template
+Another preview here
+```

--- a/packages/@docfy/ember/src/get-config.ts
+++ b/packages/@docfy/ember/src/get-config.ts
@@ -3,6 +3,7 @@ import { DocfyConfig } from '@docfy/core/lib/types';
 import remarkHBS from 'remark-hbs';
 import docfyLink from './plugins/docfy-link';
 import extractDemosToComponents from './plugins/extract-demos-to-components';
+import previewTemplate from './plugins/preview-template';
 
 const DEFAULT_CONFIG: DocfyConfig = {
   sources: [
@@ -58,7 +59,11 @@ export default function getDocfyConfig(root: string): DocfyConfig {
   if (!Array.isArray(docfyConfig.plugins)) {
     docfyConfig.plugins = [];
   }
-  docfyConfig.plugins.push(docfyLink, extractDemosToComponents);
+  docfyConfig.plugins.push(
+    docfyLink,
+    previewTemplate,
+    extractDemosToComponents
+  );
 
   if (!Array.isArray(docfyConfig.remarkPlugins)) {
     docfyConfig.remarkPlugins = [];

--- a/packages/@docfy/ember/src/index.ts
+++ b/packages/@docfy/ember/src/index.ts
@@ -11,7 +11,7 @@ import Docfy from '@docfy/core';
 import { DocfyConfig, SourceConfig } from '@docfy/core/lib/types';
 import docfyOutputTemplate from './docfy-output-template';
 import getDocfyConfig from './get-config';
-import { isDemoComponents } from './plugins/extract-demos-to-components';
+import { isDemoComponents } from './plugins/utils';
 
 function ensureDirectoryExistence(filePath: string): void {
   const dirname = path.dirname(filePath);

--- a/packages/@docfy/ember/src/plugins/preview-template.ts
+++ b/packages/@docfy/ember/src/plugins/preview-template.ts
@@ -1,0 +1,52 @@
+import visit from 'unist-util-visit';
+import { Context } from '@docfy/core/lib/types';
+import { DemoComponent, CodeNode } from './types';
+import {
+  generateDemoComponentName,
+  getExt,
+  createDemoNodes,
+  isDemoComponents,
+  replaceNode
+} from './utils';
+import path from 'path';
+
+export default function previewTemplate(ctx: Context): void {
+  const seenNames: Set<string> = new Set();
+
+  ctx.pages.forEach((page) => {
+    const demoComponents: DemoComponent[] = [];
+
+    visit(page.ast, 'code', (node: CodeNode) => {
+      if (['preview-template'].includes(node.meta || '')) {
+        demoComponents.push({
+          name: generateDemoComponentName(
+            `docfy-demo-preview-${path.basename(page.meta.url)}`,
+            seenNames
+          ),
+          chunks: [
+            {
+              snippet: node,
+              code: node.value.replace(/\\{{/g, '{{'), // un-escape hbs
+              ext: getExt(node.lang || 'hbs'),
+              type: node.meta as string
+            }
+          ]
+        });
+      }
+    });
+
+    demoComponents.forEach((demoComponent) => {
+      replaceNode(
+        page.ast.children,
+        demoComponent.chunks[0].snippet,
+        ...createDemoNodes(demoComponent)
+      );
+    });
+
+    if (isDemoComponents(page.pluginData.demoComponents)) {
+      page.pluginData.demoComponents.push(...demoComponents);
+    } else {
+      page.pluginData.demoComponents = demoComponents;
+    }
+  });
+}

--- a/packages/@docfy/ember/src/plugins/types.ts
+++ b/packages/@docfy/ember/src/plugins/types.ts
@@ -1,0 +1,33 @@
+import { Node } from 'unist';
+
+interface Literal {
+  value: string;
+}
+
+export interface CodeNode extends Node, Literal {
+  type: 'code';
+  lang?: string;
+  meta?: string;
+}
+
+export interface DemoComponent {
+  name: DemoComponentName;
+  chunks: DemoComponentChunk[];
+  description?: {
+    title?: string;
+    ast: Node;
+    editUrl?: string;
+  };
+}
+
+export interface DemoComponentName {
+  dashCase: string;
+  pascalCase: string;
+}
+
+export interface DemoComponentChunk {
+  type: string;
+  code: string;
+  ext: string;
+  snippet: Node;
+}

--- a/packages/@docfy/ember/src/plugins/utils.ts
+++ b/packages/@docfy/ember/src/plugins/utils.ts
@@ -1,0 +1,188 @@
+import { Node } from 'unist';
+import u from 'unist-builder';
+import { DemoComponent, DemoComponentName } from './types';
+
+/**
+ * Creates all the Nodes necessary to render a Demo Component.
+ *
+ * It will render something like the follwing:
+ * ```hbs
+ * <DocfyDemo as |demo|>
+ *   <demo.Example>
+ *     <ComponentName />
+ *   </demo.Example>
+ *   <demo.Description @title="Heading depth 1" @editUrl="url">
+ *     Demo markdown content
+ *   </demo.Description>
+ *   <demo.Snippets as |Snippet|>
+ *     <Snippet @name="component">
+ *       Code Snippet (with any highlight applied from remark)
+ *     </Snippet>
+ *   </demo.Snippets>
+ * </DocfyDemo>
+ * ```
+ */
+export function createDemoNodes(component: DemoComponent): Node[] {
+  const nodes: Node[] = [
+    u('html', `<DocfyDemo @id="${component.name.dashCase}" as |demo|>`)
+  ];
+
+  nodes.push(
+    u('html', '<demo.Example>'),
+    u('html', `<${component.name.pascalCase} />`),
+    u('html', '</demo.Example>')
+  );
+
+  if (component.description) {
+    nodes.push(
+      u(
+        'html',
+        `<demo.Description
+          ${
+            component.description.title
+              ? `@title="${component.description.title}" `
+              : ''
+          }${
+          component.description.editUrl
+            ? `@editUrl="${component.description.editUrl}"`
+            : ''
+        }>`
+      ),
+      component.description.ast,
+      u('html', '</demo.Description>')
+    );
+  }
+
+  if (component.chunks.length > 1) {
+    nodes.push(u('html', '<demo.Snippets as |Snippet|>'));
+    component.chunks.forEach((chunk) => {
+      nodes.push(
+        u('html', `<Snippet @name="${chunk.type}">`),
+        chunk.snippet,
+        u('html', '</Snippet>')
+      );
+    });
+    nodes.push(u('html', '</demo.Snippets>'));
+  } else {
+    component.chunks.forEach((chunk) => {
+      nodes.push(
+        u('html', `<demo.Snippet @name="${chunk.type}">`),
+        chunk.snippet,
+        u('html', '</demo.Snippet>')
+      );
+    });
+  }
+
+  nodes.push(u('html', '</DocfyDemo>'));
+
+  return nodes;
+}
+
+const MAP_LANG_TO_EXT = {
+  javascript: 'js',
+  typescript: 'ts',
+  handlebars: 'hbs',
+  'html.hbs': 'hbs',
+  'html.handlebars': 'hbs'
+};
+
+/*
+ * It returns the file extension from a lang string.
+ */
+export function getExt(lang: string): string {
+  lang = lang.toLowerCase();
+  return MAP_LANG_TO_EXT[lang] || lang;
+}
+
+/*
+ * Delete a node from a list of nodes
+ */
+export function deleteNode(
+  nodes: unknown,
+  nodeToDelete: Node | undefined
+): void {
+  if (!nodeToDelete) {
+    return;
+  }
+
+  if (Array.isArray(nodes)) {
+    const index = nodes.findIndex((item) => item === nodeToDelete);
+
+    if (index !== -1) {
+      nodes.splice(index, 1);
+    }
+  }
+}
+
+/*
+ * Replace a node from a list of nodes
+ */
+export function replaceNode(
+  nodes: unknown,
+  nodeToDelete: Node,
+  ...newNodes: Node[]
+): void {
+  if (Array.isArray(nodes)) {
+    const index = nodes.findIndex((item) => item === nodeToDelete);
+
+    if (index !== -1) {
+      nodes.splice(index, 1, ...newNodes);
+    }
+  }
+}
+
+/*
+ * Generate the component name from the source path of the demo
+ *
+ * It returns both dash case and pastal case.
+ * The dash-case can be used for the file name and the PascalCase for the
+ * rendering of the component.
+ */
+export function generateDemoComponentName(
+  identifier: string,
+  seenNames: Set<string>,
+  tentativeCount = 1
+): DemoComponentName {
+  const dashCase = identifier
+    .split('.')[0]
+    .toLowerCase()
+    .replace(/\/|\\/g, '-')
+    .replace(/[^a-zA-Z0-9|-]/g, '');
+
+  const pascalCase = dashCase
+    .replace(/(\w)(\w*)/g, function (_, g1, g2) {
+      return `${g1.toUpperCase()}${g2.toLowerCase()}`;
+    })
+    .replace(/-/g, '');
+
+  if (seenNames.has(dashCase)) {
+    return generateDemoComponentName(
+      `${dashCase}${tentativeCount}`,
+      seenNames,
+      tentativeCount + 1
+    );
+  }
+
+  seenNames.add(dashCase);
+  return {
+    dashCase,
+    pascalCase
+  };
+}
+
+/**
+ * Checks if a property is of type DemoComponent[]
+ */
+export function isDemoComponents(
+  components: unknown
+): components is DemoComponent[] {
+  if (
+    Array.isArray(components) &&
+    typeof components[0] == 'object' &&
+    {}.hasOwnProperty.call(components[0], 'name') &&
+    {}.hasOwnProperty.call(components[0], 'chunks')
+  ) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
It will extract any code block containing `preview-template` meta to a component.

eg.

    ```hbs preview-template
     <DocfyLink @to="/" class="text-blue-700">This is a link to index</DocfyLink>
     <div class="p-4 my-2 border border-blue-500 rounded">
       I can have any hbs here and I can use any component avaliable in the host app.
     </div>
     ```

<img width="945" alt="Screen Shot 2020-05-12 at 8 13 01 PM" src="https://user-images.githubusercontent.com/230476/81767551-891e8600-948d-11ea-9a13-d786b8247154.png">
