### PR TITLE
Use V-File for parsing and processing remark plugins

### DIFF
--- a/packages/@docfy/core/package.json
+++ b/packages/@docfy/core/package.json
@@ -30,6 +30,7 @@
     "remark-parse": "^8.0.2",
     "remark-slug": "^6.0.0",
     "remark-stringify": "^8.0.0",
+    "to-vfile": "^6.1.0",
     "trough": "^1.0.5",
     "unified": "^9.0.0",
     "unist-util-visit": "^2.0.2",

--- a/packages/@docfy/core/src/index.ts
+++ b/packages/@docfy/core/src/index.ts
@@ -1,7 +1,7 @@
 import glob from 'fast-glob';
-import fs from 'fs';
 import path from 'path';
 import trough, { Through } from 'trough';
+import toVfile from 'to-vfile';
 import {
   PageContent,
   Context,
@@ -123,9 +123,11 @@ export default class Docfy {
       ''
     );
 
-    const markdown = fs.readFileSync(fullPath).toString();
+    const vFile = toVfile.readSync(fullPath);
+    const markdown = vFile.contents.toString();
     const ast = this.context.remark.runSync(
-      this.context.remark.parse(markdown)
+      this.context.remark.parse(vFile),
+      vFile
     );
     const frontmatter = parseFrontmatter(fullPath, ast);
 

--- a/packages/@docfy/core/src/plugins/combine-demos.ts
+++ b/packages/@docfy/core/src/plugins/combine-demos.ts
@@ -24,7 +24,7 @@ import { PageContent, Context } from '../types';
 function findDemoOwner(contents: PageContent[], demoSource: string): number {
   const folder = path.basename(path.dirname(demoSource));
 
-  let parentName = folder.replace('-demo', '');
+  let parentName = folder.replace(/-demo$/, '');
   if (parentName === 'demo') {
     parentName = path.basename(path.dirname(path.dirname(demoSource)));
   }

--- a/packages/@docfy/core/types/to-vfile.d.ts
+++ b/packages/@docfy/core/types/to-vfile.d.ts
@@ -1,0 +1,10 @@
+declare module 'to-vfile' {
+  import { VFile } from 'vfile'; // eslint-disable-line
+
+  // eslint-disable-next-line
+  class ToVFile {
+    static readSync(filepath: string): VFile;
+  }
+
+  export default ToVFile;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -15336,6 +15336,14 @@ to-utf8@0.0.1:
   resolved "https://registry.yarnpkg.com/to-utf8/-/to-utf8-0.0.1.tgz#d17aea72ff2fba39b9e43601be7b3ff72e089852"
   integrity sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=
 
+to-vfile@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/to-vfile/-/to-vfile-6.1.0.tgz#5f7a3f65813c2c4e34ee1f7643a5646344627699"
+  integrity sha512-BxX8EkCxOAZe+D/ToHdDsJcVI4HqQfmw0tCkp31zf3dNP/XWIAjU4CmeuSwsSoOzOTqHPOL0KUzyZqJplkD0Qw==
+  dependencies:
+    is-buffer "^2.0.0"
+    vfile "^4.0.0"
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"


### PR DESCRIPTION
Using V-File will pass the some metadata about the file to remark plugins, such as the file location. This is required for plugins like [remark-code-import](https://github.com/kevin940726/remark-code-import) to work properly.