### PR TITLE
[Core] Remove unnecessary index

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,8 @@ import {
   replaceInternalLinks,
   staticAssets,
   toc,
-  uniquefyUrls
+  uniquefyUrls,
+  removeUnnecessaryIndex
 } from './plugins';
 import { getRepoEditUrl } from './-private/repo-info';
 import { transformToNestedPageMetadata } from './-private/nested-page-metadata';
@@ -50,6 +51,7 @@ export default class Docfy {
     this.pipeline = trough<Context>()
       .use<SourceConfig[]>(this.initializePipeline.bind(this))
       .use(combineDemos)
+      .use(removeUnnecessaryIndex)
       .use(uniquefyUrls)
       .use(replaceInternalLinks)
       .use(staticAssets);

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -4,3 +4,4 @@ export { replaceInternalLinks } from './replace-internal-links';
 export { staticAssets } from './static-assets';
 export { toc } from './toc';
 export { uniquefyUrls } from './uniquefy-urls';
+export { removeUnnecessaryIndex } from './remove-unnecessary-index';

--- a/packages/core/src/plugins/remove-unnecessary-index.ts
+++ b/packages/core/src/plugins/remove-unnecessary-index.ts
@@ -1,0 +1,29 @@
+import { Context } from '../types';
+
+/**
+ * This plugin removes unnecessary index pages.
+ * These can happen when there are folders with an
+ * index.md/readme.md and no subfolder/pages nested.
+ */
+export function removeUnnecessaryIndex(ctx: Context): void {
+  const urls: string[] = [];
+  ctx.pages.forEach((page) => {
+    urls.push(page.meta.url);
+  });
+
+  ctx.pages.forEach((page) => {
+    if (/\/$/.test(page.meta.url)) {
+      const matched = urls.filter((url) => {
+        const r = new RegExp(page.meta.url);
+
+        return r.test(url);
+      });
+      if (matched.length == 1) {
+        page.meta.url = page.meta.url.replace(
+          /\/$/,
+          page.sourceConfig.urlSuffix || ''
+        );
+      }
+    }
+  });
+}

--- a/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/something-else.md
+++ b/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/something-else.md
@@ -1,0 +1,7 @@
+---
+order: 2
+category: category1
+subcategory: components
+---
+
+Some other file next to a index.md

--- a/packages/core/tests/__snapshots__/generating-edit-url.test.ts.snap
+++ b/packages/core/tests/__snapshots__/generating-edit-url.test.ts.snap
@@ -35,6 +35,10 @@ Array [
     "https://github.com/user/repo/edit/dev/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/index.md",
   ],
   Array [
+    "packages/package1/components/form/something-else.md",
+    "https://github.com/user/repo/edit/dev/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/something-else.md",
+  ],
+  Array [
     "packages/package2/docs/overview.md",
     "https://bitbucket.org/user/repo/src/dev/packages/core/tests/__fixtures__/monorepo/packages/package2/docs/overview.md?mode=edit&spa=0&at=dev&fileviewer=file-view-default",
   ],

--- a/packages/core/tests/__snapshots__/headings-extraction.test.ts.snap
+++ b/packages/core/tests/__snapshots__/headings-extraction.test.ts.snap
@@ -108,6 +108,10 @@ Array [
     "packages/package1/components/form/index.md",
     Array [],
   ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    Array [],
+  ],
 ]
 `;
 
@@ -203,6 +207,10 @@ Array [
   ],
   Array [
     "packages/package1/components/form/index.md",
+    Array [],
+  ],
+  Array [
+    "packages/package1/components/form/something-else.md",
     Array [],
   ],
 ]

--- a/packages/core/tests/__snapshots__/integration-nested-page-metadata.test.ts.snap
+++ b/packages/core/tests/__snapshots__/integration-nested-page-metadata.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Generates runtime output it should have generated the nestedPageMetadata, 1`] = `
+exports[`Generates runtime output it should have generated the nestedPageMetadata 1`] = `
 Object {
   "children": Array [
     Object {
@@ -8,28 +8,7 @@ Object {
         Object {
           "children": Array [
             Object {
-              "children": Array [
-                Object {
-                  "children": Array [],
-                  "label": "form",
-                  "name": "form",
-                  "pages": Array [
-                    Object {
-                      "editUrl": "https://github.com/user/repo/edit/master/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/index.md",
-                      "frontmatter": Object {
-                        "category": "category1",
-                        "order": 1,
-                        "subcategory": "components",
-                      },
-                      "headings": Array [],
-                      "pluginData": Object {},
-                      "relativeUrl": "",
-                      "title": "Form Component",
-                      "url": "/docs/category1/components/form/",
-                    },
-                  ],
-                },
-              ],
+              "children": Array [],
               "label": "components",
               "name": "components",
               "pages": Array [
@@ -45,6 +24,32 @@ Object {
                   "relativeUrl": "button",
                   "title": "Button Component",
                   "url": "/docs/category1/components/button",
+                },
+                Object {
+                  "editUrl": "https://github.com/user/repo/edit/master/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/index.md",
+                  "frontmatter": Object {
+                    "category": "category1",
+                    "order": 1,
+                    "subcategory": "components",
+                  },
+                  "headings": Array [],
+                  "pluginData": Object {},
+                  "relativeUrl": "form",
+                  "title": "Form Component",
+                  "url": "/docs/category1/components/form",
+                },
+                Object {
+                  "editUrl": "https://github.com/user/repo/edit/master/packages/core/tests/__fixtures__/monorepo/packages/package1/components/form/something-else.md",
+                  "frontmatter": Object {
+                    "category": "category1",
+                    "order": 2,
+                    "subcategory": "components",
+                  },
+                  "headings": Array [],
+                  "pluginData": Object {},
+                  "relativeUrl": "something-else",
+                  "title": "something-else",
+                  "url": "/docs/category1/components/something-else",
                 },
               ],
             },

--- a/packages/core/tests/__snapshots__/integration-remark-plugins.test.ts.snap
+++ b/packages/core/tests/__snapshots__/integration-remark-plugins.test.ts.snap
@@ -76,6 +76,11 @@ config.</p>
     "<h1 id=\\"form-component\\"><a href=\\"#form-component\\" aria-hidden=\\"true\\" tabindex=\\"-1\\"><span class=\\"icon icon-link\\"></span></a>Form Component</h1>
 ",
   ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    "<p>Some other file next to a index.md</p>
+",
+  ],
 ]
 `;
 
@@ -153,6 +158,11 @@ config.</p>
   Array [
     "packages/package1/components/form/index.md",
     "<h1 id=\\"form-component\\">Form Component<a href=\\"#form-component\\" aria-hidden=\\"true\\" tabindex=\\"-1\\"><span class=\\"icon icon-link\\"></span></a></h1>
+",
+  ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    "<p>Some other file next to a index.md</p>
 ",
   ],
 ]

--- a/packages/core/tests/__snapshots__/url-schema-auto.test.ts.snap
+++ b/packages/core/tests/__snapshots__/url-schema-auto.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`URLs should be correctly generated when urlSchema is set to auto base base, no url prefix, no suffix 1`] = `
+exports[`URLs should be correctly generated when urlSchema is set to auto base, no url prefix, no suffix 1`] = `
 Array [
   Array [
     "README.md",
@@ -41,6 +41,10 @@ Array [
   Array [
     "packages/package1/components/form/index.md",
     "/packages/package1/components/form/",
+  ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    "/packages/package1/components/form/something-else",
   ],
 ]
 `;
@@ -86,6 +90,10 @@ Array [
   Array [
     "packages/package1/components/form/index.md",
     "/docs/packages/package1/components/form/",
+  ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    "/docs/packages/package1/components/form/something-else.html",
   ],
 ]
 `;

--- a/packages/core/tests/__snapshots__/url-schema-manual.test.ts.snap
+++ b/packages/core/tests/__snapshots__/url-schema-manual.test.ts.snap
@@ -40,7 +40,11 @@ Array [
   ],
   Array [
     "packages/package1/components/form/index.md",
-    "/category1/components/form/",
+    "/category1/components/form",
+  ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    "/category1/components/something-else",
   ],
 ]
 `;
@@ -85,7 +89,11 @@ Array [
   ],
   Array [
     "packages/package1/components/form/index.md",
-    "/docs/category1/components/form/",
+    "/docs/category1/components/form.html",
+  ],
+  Array [
+    "packages/package1/components/form/something-else.md",
+    "/docs/category1/components/something-else.html",
   ],
 ]
 `;

--- a/packages/core/tests/integration-nested-page-metadata.test.ts
+++ b/packages/core/tests/integration-nested-page-metadata.test.ts
@@ -24,7 +24,7 @@ describe('Generates runtime output', () => {
     ]);
   });
 
-  test('it should have generated the nestedPageMetadata,', async () => {
+  test('it should have generated the nestedPageMetadata', async () => {
     expect(result.nestedPageMetadata).toMatchSnapshot();
   });
 });

--- a/packages/core/tests/url-schema-auto.test.ts
+++ b/packages/core/tests/url-schema-auto.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 const root = path.resolve(__dirname, './__fixtures__/monorepo');
 
 describe('URLs should be correctly generated when urlSchema is set to auto', () => {
-  test('base base, no url prefix, no suffix', async () => {
+  test('base, no url prefix, no suffix', async () => {
     const docfy = new Docfy();
     const result = await docfy.run([
       {


### PR DESCRIPTION
Adds a default core plugin that removes unnecessary index pages.
These can happen when there are folders with an index.md/readme.md and no subfolder/pages nested.