### PR TITLE
Use Glimmer component backing class rather than a templateOnly component

### DIFF
--- a/packages/ember/docs/writing-demos.md
+++ b/packages/ember/docs/writing-demos.md
@@ -33,11 +33,14 @@ of the code block. The possible values are `component`, `template`, and `styles`
 ## Preview Template
 
 When writing documentation in Ember apps, we might want to write some template
-code to demonstrate how to use a component, while having the code been executed
-as well. Creating a demo markdown might be too much of an effort; for this purpose,
-Docfy has another feature called `preview-template`. It will extract the template
-from the markdown code block then it will create a template only component. It will
-also add the code snippet so users can see the code.
+code to demonstrate how to use a component whilst also having the code
+executed to embed the same template into the rendered markdown. Creating a
+demo markdown might be too much of an effort; for this purpose, Docfy has
+another feature called `preview-template`. It will extract the template from
+the markdown code block and create a component backed by an empty Glimmer
+component class to provide a `this` context so helpers such as `mut` or `set`
+can be used within the demonstration. It will also add the code snippet so
+users can see the code.
 
 Below is an example of how it works:
 

--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -17,8 +17,8 @@ import debugFactory from 'debug';
 const debug = debugFactory('@docfy/ember');
 
 const templateOnlyComponent = `
-import templateOnly from '@ember/component/template-only';
-export default templateOnly();
+import Component from '@glimmer/component';
+export default class extends Component {}
 `;
 
 function ensureDirectoryExistence(filePath: string): void {


### PR DESCRIPTION
When writing documentation it's super handy to be able to write a good
usage example without having to write your own Glimmer component backing
class for the example/template.

Template only components are great for this, but sometimes you would
like to use the `mut` or `set` helper to help to illustrate the
functionality of the component a little better, again without having to
write an additional Glimmer component backing class just to you can
access `this` from within the component.

This commit changes the template backing code to use a full, but empty,
`@glimmer/component` class rather than `templateOnly()`. This means your
usage example can reference `this` and then use either `mut` or `set`
helpers.

The only downside I can see here is that using `templateOnly` is
slightly lighter-weight than using a full glimmer component class, but
in the context of writing documentation, there's something to be said for
making writing documentation as friction free as possible versus making
things light-weight.

P.S. Thanks for the great project 🎉 