### PR TITLE
Add treeFor cache

### DIFF
--- a/packages/ember/package.json
+++ b/packages/ember/package.json
@@ -38,6 +38,7 @@
     "broccoli-node-api": "^1.7.0",
     "broccoli-plugin": "^4.0.3",
     "broccoli-source": "^3.0.0",
+    "calculate-cache-key-for-tree": "2.0.0",
     "debug": "^4.3.1",
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.3.1",

--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -137,7 +137,7 @@ module.exports = {
 
   // Re-enables caching of this addon, due to opting out
   // of the caching implicitly by specifying treeFor* methods
-  cacheKeyForTree(treeType) {
+  cacheKeyForTree(treeType: string): string {
     switch (treeType) {
       case 'app': {
         const sources = (this.docfyConfig as DocfyConfig).sources

--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -13,6 +13,7 @@ import { DemoComponentChunk } from './plugins/types';
 import docfyOutputTemplate from './docfy-output-template';
 import getDocfyConfig from './get-config';
 import { isDemoComponents } from './plugins/utils';
+import cacheKeyForTree from 'calculate-cache-key-for-tree';
 import debugFactory from 'debug';
 const debug = debugFactory('@docfy/ember');
 
@@ -132,6 +133,12 @@ module.exports = {
       this.bridge = new BroccoliBridge();
     }
     this._super.included.apply(this, args);
+  },
+
+  // Re-enables caching of this addon, due to opting out
+  // of the caching implicitly by specifying treeFor* methods
+  cacheKeyForTree(treeType) {
+    return cacheKeyForTree(treeType, this);
   },
 
   treeForApp(tree: Node): Node {

--- a/packages/ember/src/index.ts
+++ b/packages/ember/src/index.ts
@@ -138,7 +138,16 @@ module.exports = {
   // Re-enables caching of this addon, due to opting out
   // of the caching implicitly by specifying treeFor* methods
   cacheKeyForTree(treeType) {
-    return cacheKeyForTree(treeType, this);
+    switch (treeType) {
+      case 'app': {
+        const sources = (this.docfyConfig as DocfyConfig).sources
+          .map((item) => item.root)
+          .join(',');
+        return cacheKeyForTree(treeType, this, [sources]);
+      }
+      default:
+        return cacheKeyForTree(treeType, this);
+    }
   },
 
   treeForApp(tree: Node): Node {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5678,7 +5678,7 @@ cacheable-request@^2.1.1:
     normalize-url "2.0.1"
     responselike "1.0.2"
 
-calculate-cache-key-for-tree@^2.0.0:
+calculate-cache-key-for-tree@2.0.0, calculate-cache-key-for-tree@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/calculate-cache-key-for-tree/-/calculate-cache-key-for-tree-2.0.0.tgz#7ac57f149a4188eacb0a45b210689215d3fef8d6"
   integrity sha512-Quw8a6y8CPmRd6eU+mwypktYCwUcf8yVFIRbNZ6tPQEckX9yd+EBVEPC/GSZZrMWH9e7Vz4pT7XhpmyApRByLQ==


### PR DESCRIPTION
See these PRs for more context and info:
 - https://github.com/babel/ember-cli-babel/pull/421
 - https://github.com/embroider-build/embroider/pull/1052
 
 unscientifically, with this change, I saw our slowest docfy app go from building in 140s to 84s