### PR TITLE
Fix bug where PascalCase for strings with numbers was incorrect

### DIFF
--- a/packages/ember/dummy-docs/packages/ember/components/docfy-with-hyphenated-number-2-demo/demo1.md
+++ b/packages/ember/dummy-docs/packages/ember/components/docfy-with-hyphenated-number-2-demo/demo1.md
@@ -1,0 +1,26 @@
+---
+order: 1
+---
+
+# Demo of DocfyLink component
+
+This is a cool feature.
+
+[Link from a demo](../docfy-output.md)
+
+```hbs template
+<div data-test-id="demo-1">
+  This is my Demo:
+
+  <DocfyLink @to={{this.url}}>My Link</DocfyLink>
+</div>
+<div data-test-id="demo-1-js-data">{{this.url}}</div>
+```
+
+```js component
+import Component from '@glimmer/component';
+
+export default class MyDemo extends Component {
+  url = '/docs/ember/';
+}
+```

--- a/packages/ember/dummy-docs/packages/ember/components/docfy-with-hyphenated-number-2-demo/demo1.md
+++ b/packages/ember/dummy-docs/packages/ember/components/docfy-with-hyphenated-number-2-demo/demo1.md
@@ -4,14 +4,13 @@ order: 1
 
 # Demo of DocfyLink component
 
-This is a cool feature.
-
 [Link from a demo](../docfy-output.md)
 
 ```hbs template
 <div data-test-id="demo-1">
   This is my Demo:
 
+  <span class='hyphenated-demo'>Assertable DOM node</span>
   <DocfyLink @to={{this.url}}>My Link</DocfyLink>
 </div>
 <div data-test-id="demo-1-js-data">{{this.url}}</div>

--- a/packages/ember/dummy-docs/packages/ember/components/docfy-with-hyphenated-number-2.md
+++ b/packages/ember/dummy-docs/packages/ember/components/docfy-with-hyphenated-number-2.md
@@ -1,0 +1,9 @@
+---
+category: ember
+subcategory: components
+---
+
+# Docfy With Hyphenated Number 2
+
+Testing doc pages with numbers in their name and how that corresponds with
+automatic component registration.

--- a/packages/ember/src/plugins/utils.ts
+++ b/packages/ember/src/plugins/utils.ts
@@ -153,6 +153,9 @@ export function generateDemoComponentName(
     .replace(/(\w)(\w*)/g, function (_, g1, g2) {
       return `${g1.toUpperCase()}${g2.toLowerCase()}`;
     })
+    .replace(/-(\d+)/g, function (_, g1) {
+      return `_${g1}`;
+    })
     .replace(/-/g, '');
 
   if (seenNames.has(dashCase)) {

--- a/packages/ember/tests/acceptance/extracted-demos-test.ts
+++ b/packages/ember/tests/acceptance/extracted-demos-test.ts
@@ -117,4 +117,16 @@ module('Acceptance | extracted demos', function (hooks) {
 
     assert.strictEqual(demosAll?.length, 2);
   });
+
+  test('it correctly resolves demo components with hyphenated numbers', async function (assert) {
+    await visit('/docs/ember/components/docfy-with-hyphenated-number-2');
+
+    // Since this page has a hyphenated number in it, demo components must be transformed with
+    // preceding underscores like this:
+    //   <DocfyDemoPackagesEmberComponentsDocfyWithHyphenatedNumber_2Demo1/>
+
+    assert
+      .dom('.docfy-demo__example .hyphenated-demo')
+      .hasText('Assertable DOM node');
+  });
 });

--- a/packages/ember/tests/fastboot/docs-test.js
+++ b/packages/ember/tests/fastboot/docs-test.js
@@ -25,7 +25,7 @@ module('FastBoot | docs', function (hooks) {
     assert
       .dom('[data-test-id="docs-nav"]')
       .hasText(
-        'Welcome to Docfy Introduction Installation Overview @docfy/core Overview Helpers genereateFlatOutput genereateNestedOutput @docfy/ember Working with Ember Installation Components Docfy Link Component Docfy Output Component Plugins Manual Demo Insertion'
+        'Welcome to Docfy Introduction Installation Overview @docfy/core Overview Helpers genereateFlatOutput genereateNestedOutput @docfy/ember Working with Ember Installation Components Docfy Link Component Docfy Output Component Docfy With Hyphenated Number 2 Plugins Manual Demo Insertion'
       );
   });
 

--- a/packages/ember/tests/integration/components/docfy-output-test.ts
+++ b/packages/ember/tests/integration/components/docfy-output-test.ts
@@ -49,7 +49,7 @@ module('Integration | Component | DocfyOutput', function (hooks) {
     assert
       .dom('[data-test-id="flat-urls"]')
       .hasText(
-        '/docs/ /docs/introduction /docs/installation /docs/overview /docs/core/overview /docs/core/helpers/genereate-flat-output /docs/core/helpers/genereate-nested-output /docs/ember/ /docs/ember/installation /docs/ember/components/docfy-link /docs/ember/components/docfy-output /docs/ember/plugins/manual-demo-insertion'
+        '/docs/ /docs/introduction /docs/installation /docs/overview /docs/core/overview /docs/core/helpers/genereate-flat-output /docs/core/helpers/genereate-nested-output /docs/ember/ /docs/ember/installation /docs/ember/components/docfy-link /docs/ember/components/docfy-output /docs/ember/components/docfy-with-hyphenated-number-2 /docs/ember/plugins/manual-demo-insertion'
       );
   });
 

--- a/packages/ember/tests/unit/demo-component-generation-test.ts
+++ b/packages/ember/tests/unit/demo-component-generation-test.ts
@@ -20,6 +20,8 @@ module('Unit | Demo component generation', function (hooks) {
     // dummy/docs/packages/ember/components/docfy-link-demo/{demo-file}.md
     has('packages-ember-components-docfy-link-demo1');
     has('packages-ember-components-docfy-link-demo2');
+    // dummy/docs/packages/ember/components/docfy-with-hyphenated-number-2/{demo-file}.md
+    has('packages-ember-components-docfy-with-hyphenated-number-2-demo1');
     // where do these come from?
     has('preview-ember');
     has('preview-ember1');

--- a/packages/ember/tests/unit/services/docfy-test.ts
+++ b/packages/ember/tests/unit/services/docfy-test.ts
@@ -119,7 +119,10 @@ module('Unit | Service | docfy', function (hooks) {
         .stub(routerService, 'currentURL')
         .get(() => '/docs/ember/plugins/manual-demo-insertion');
 
-      assert.equal(service.previousPage()?.title, 'Docfy Output Component');
+      assert.equal(
+        service.previousPage()?.title,
+        'Docfy With Hyphenated Number 2'
+      );
       assert.equal(service.nextPage()?.title, undefined);
     });
 


### PR DESCRIPTION
When the AST transformer generates component invocation nodes, it would handle numbers in paths incorrectly when converting to pascal case.

**Before**

`components/this-is-number-2` -> `<ThisIsNumber2 />`

**After**  

`components/this-is-number-2` -> `<ThisIsNumber_2 />`