### PR TITLE
docs: add Contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+## How to install
+Make sure you are using yarn (version 1)
+
+In the root folder:
+
+```
+yarn install
+```
+
+Then:
+
+```
+yarn compile
+```
+
+
+## Ember
+
+```
+cd packages/ember
+yarn start
+```


### PR DESCRIPTION
I didn't see instructions on how to start the local server for the ember package.

Doing this seemed to work for me so I added it to a CONTRIBUTING.md doc.

Before I just tried
1. `yarn start`
2. `cd packages/ember`
3. `yarn start`

And that was erroring for me because the packages needed to be compiled first.