### PR TITLE
Support both ESM and CJS for config files

### DIFF
--- a/packages/ember/src/get-config.ts
+++ b/packages/ember/src/get-config.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { pathToFileURL } from 'url';
 import { DocfyConfig } from '@docfy/core/lib/types';
 import remarkHbs from 'remark-hbs';
 import replaceInternalLinksWithDocfyLink from './plugins/replace-internal-links-with-docfy-link';
@@ -19,52 +20,58 @@ interface EmberDocfyConfig extends DocfyConfig {
   remarkHbsOptions?: RemarkHbsOptions;
 }
 
-export default function getDocfyConfig(root: string): EmberDocfyConfig {
+export default async function getDocfyConfig(
+  root: string
+): Promise<EmberDocfyConfig> {
   const configPath = path.join(root, '.docfy-config.js');
-  let docfyConfig: EmberDocfyConfig = DEFAULT_CONFIG;
+  let docfyConfig: Partial<EmberDocfyConfig> = {};
 
-  const pkg = require(path.join(root, 'package.json')); // eslint-disable-line
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const pkg = require(path.join(root, 'package.json'));
 
   try {
-    docfyConfig = require(configPath); // eslint-disable-line @typescript-eslint/no-require-imports
-  } catch (e) {
-    if (!e.message.match(new RegExp(`Cannot find module .${configPath}`))) {
+    // Attempt to require (CJS)
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    docfyConfig = require(configPath);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (e: any) {
+    // Fallback to ESM if the error indicates ESM-only module
+    const isESMError =
+      e.code === 'ERR_REQUIRE_ESM' ||
+      e.message?.includes('must use import to load ES Module') ||
+      e.message?.includes('Cannot use import statement outside a module');
+
+    if (isESMError || e.code === 'ERR_MODULE_NOT_FOUND') {
+      try {
+        const imported = await import(pathToFileURL(configPath).href);
+        docfyConfig = imported?.default ?? imported;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } catch (esmErr: any) {
+        const notFound =
+          esmErr.code === 'ERR_MODULE_NOT_FOUND' ||
+          esmErr.message?.includes('Cannot find module');
+        if (!notFound) {
+          throw esmErr;
+        }
+        docfyConfig = {};
+      }
+    } else {
       throw e;
     }
   }
 
-  if (typeof docfyConfig === 'object') {
-    if (typeof docfyConfig.sources === 'undefined') {
-      docfyConfig.sources = DEFAULT_CONFIG.sources;
-    }
-
-    if (!Array.isArray(docfyConfig.sources)) {
-      console.warn(
-        'Docfy expected an array for sources in .docfy-config.js, received ',
-        typeof docfyConfig.sources
-      );
-
-      docfyConfig.sources = DEFAULT_CONFIG.sources;
-    }
-  } else {
-    docfyConfig = DEFAULT_CONFIG;
+  if (typeof docfyConfig !== 'object' || docfyConfig == null) {
+    docfyConfig = {};
   }
 
-  const repoUrl = pkg.repository.url || pkg.repository;
-
-  if (
-    !docfyConfig.repository &&
-    typeof repoUrl === 'string' &&
-    repoUrl !== ''
-  ) {
-    docfyConfig.repository = {
-      url: repoUrl
-    };
+  if (!Array.isArray(docfyConfig.sources)) {
+    docfyConfig.sources = DEFAULT_CONFIG.sources;
   }
 
   if (!Array.isArray(docfyConfig.plugins)) {
     docfyConfig.plugins = [];
   }
+
   docfyConfig.plugins.unshift(
     replaceInternalLinksWithDocfyLink,
     previewTemplate,
@@ -80,11 +87,23 @@ export default function getDocfyConfig(root: string): EmberDocfyConfig {
     docfyConfig.remarkHbsOptions || {}
   ]);
 
+  const repoUrl = pkg.repository?.url || pkg.repository;
+
+  if (
+    !docfyConfig.repository &&
+    typeof repoUrl === 'string' &&
+    repoUrl !== ''
+  ) {
+    docfyConfig.repository = {
+      url: repoUrl
+    };
+  }
+
   docfyConfig.sources.forEach((source) => {
     if (typeof source.root === 'undefined') {
       source.root = path.join(root, 'docs');
     }
   });
 
-  return docfyConfig;
+  return docfyConfig as EmberDocfyConfig;
 }


### PR DESCRIPTION
I am not sure if this is the correct way to handle things or if we would prefer to switch to ESM only, but I think we should add ESM support, since a lot of remark plugins are now ESM only.