### PR TITLE
feat: add section ordering configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,6 +24,10 @@ const docfy = new Docfy({
   repository: {
     url: 'https://github.com/josemarluedke/docfy',
   },
+  sections: {
+    docs: { label: 'Documentation', order: 1 },
+    api: { label: 'API Reference', order: 2 },
+  },
 });
 ```
 
@@ -78,9 +82,42 @@ You can also pass options to rehype plugins the same way as remark plugins.
 
 **`default`** 6
 
-### `labels`
+### `sections`
+
+• **sections**? : _Record‹string, SectionConfig›_ - Configuration for documentation sections (folders).
+
+This allows you to set custom labels and control the order of sections in your documentation navigation.
+
+Example:
+
+```js
+const config = {
+  sections: {
+    'getting-started': { label: 'Getting Started', order: 1 },
+    api: { label: 'API Reference', order: 2 },
+    guides: { label: 'Guides', order: 3 },
+    examples: { label: 'Examples' }, // No order, will be alphabetically sorted
+  },
+};
+```
+
+#### `SectionConfig`
+
+- **label**? : _string_ - Custom label for the section. If not provided, the folder name will be used.
+- **order**? : _number_ - Order of the section. Sections with lower order values appear first. Sections without an order value will be sorted alphabetically and appear after ordered sections.
+
+#### Ordering Behavior
+
+- Sections with an `order` value are sorted numerically (lowest first)
+- Sections without an `order` value are sorted alphabetically by label
+- Ordered sections always appear before unordered sections
+- Works with nested sections - the configuration applies to all levels
+
+### `labels` (deprecated)
 
 • **labels**? : _Record‹string, string›_ - Labels to be used while generating `nestedPageMetadata`.
+
+**Note:** This option is deprecated. Use `sections` instead for more control over section ordering and labels.
 
 ### `repository`
 

--- a/packages/core/src/-private/nested-page-metadata.ts
+++ b/packages/core/src/-private/nested-page-metadata.ts
@@ -1,4 +1,4 @@
-import { PageMetadata, NestedPageMetadata } from '../types';
+import { PageMetadata, NestedPageMetadata, SectionConfig } from '../types';
 
 function findChild(node: NestedPageMetadata, name: string): NestedPageMetadata | undefined {
   return node.children.find(item => {
@@ -14,14 +14,34 @@ function sortByOrder(pages: PageMetadata[]): PageMetadata[] {
   });
 }
 
+function getSectionLabel(
+  name: string,
+  sections: Record<string, SectionConfig> = {},
+  labels: Record<string, string> = {}
+): string {
+  // Prefer sections config, fall back to labels (backward compat), then use name
+  if (sections[name]?.label) {
+    return sections[name].label;
+  }
+  if (labels[name]) {
+    return labels[name];
+  }
+  return name;
+}
+
+function getSectionOrder(name: string, sections: Record<string, SectionConfig> = {}): number | undefined {
+  return sections[name]?.order;
+}
+
 export function transformToNestedPageMetadata(
   pages: PageMetadata[],
   labels: Record<string, string> = {},
-  existingObj?: NestedPageMetadata
+  existingObj?: NestedPageMetadata,
+  sections: Record<string, SectionConfig> = {}
 ): NestedPageMetadata {
   const node: NestedPageMetadata = existingObj || {
     name: '/',
-    label: labels['/'] || '/',
+    label: getSectionLabel('/', sections, labels),
     pages: [],
     children: [],
   };
@@ -46,13 +66,32 @@ export function transformToNestedPageMetadata(
         if (!child) {
           child = {
             name: name,
-            label: labels[name] || name,
+            label: getSectionLabel(name, sections, labels),
             pages: [],
             children: [],
           };
           node.children.push(child);
 
           node.children.sort((a, b) => {
+            const aOrder = getSectionOrder(a.name, sections);
+            const bOrder = getSectionOrder(b.name, sections);
+
+            // If both have order, sort by order
+            if (aOrder !== undefined && bOrder !== undefined) {
+              return aOrder - bOrder;
+            }
+
+            // If only a has order, a comes first
+            if (aOrder !== undefined) {
+              return -1;
+            }
+
+            // If only b has order, b comes first
+            if (bOrder !== undefined) {
+              return 1;
+            }
+
+            // If neither has order, sort alphabetically by label
             const labelA = a.label.toUpperCase();
             const labelB = b.label.toUpperCase();
             if (labelA < labelB) {
@@ -67,7 +106,7 @@ export function transformToNestedPageMetadata(
         }
 
         item.relativeUrl = urlParts.join('/');
-        transformToNestedPageMetadata([item], labels, child);
+        transformToNestedPageMetadata([item], labels, child, sections);
 
         sortByOrder(child.pages);
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,7 +85,9 @@ class Docfy {
             staticAssets: ctx.staticAssets,
             nestedPageMetadata: transformToNestedPageMetadata(
               ctx.pages.map(p => p.meta),
-              ctx.options.labels
+              ctx.options.labels,
+              undefined,
+              ctx.options.sections
             ),
           });
         }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -174,6 +174,20 @@ export type PluginWithOptionsFunction<T = PluginOptions> = (options?: T) => Plug
 
 export type PluginList = (Plugin | PluginWithOptions<any> | PluginWithOptionsFunction<any>)[];
 
+export interface SectionConfig {
+  /**
+   * Custom label for the section. If not provided, the folder name will be used.
+   */
+  label?: string;
+
+  /**
+   * Order of the section. Sections with lower order values appear first.
+   * Sections without an order value will be sorted alphabetically and appear
+   * after ordered sections.
+   */
+  order?: number;
+}
+
 export interface Options {
   /**
    * A list of Docfy plugins.
@@ -228,8 +242,24 @@ export interface Options {
 
   /**
    * Labels to be used while generating nestedPageMetadata
+   * @deprecated Use `sections` instead for more control over section ordering and labels
    */
   labels?: Record<string, string>;
+
+  /**
+   * Configuration for documentation sections (folders).
+   * Allows you to set custom labels and control the order of sections.
+   *
+   * Example:
+   * ```js
+   * sections: {
+   *   components: { label: 'Components', order: 1 },
+   *   core: { label: '@docfy/core', order: 2 },
+   *   docs: { label: 'Documentation' } // No order, will be alphabetically sorted
+   * }
+   * ```
+   */
+  sections?: Record<string, SectionConfig>;
 
   /**
    * The static asset path to be used in the their url.

--- a/packages/core/tests/section-ordering.test.ts
+++ b/packages/core/tests/section-ordering.test.ts
@@ -1,0 +1,174 @@
+import Docfy from '../src';
+import { DocfyResult } from '../src/types';
+import path from 'path';
+
+const root = path.resolve(__dirname, './__fixtures__/monorepo');
+
+describe('Section ordering', () => {
+  let result: DocfyResult;
+
+  beforeAll(async () => {
+    const docfy = new Docfy({
+      sections: {
+        category2: { label: 'Category 2', order: 1 },
+        category1: { label: 'Category 1', order: 2 },
+        // test-custom has no order, should be alphabetically sorted after ordered sections
+      },
+    });
+    result = await docfy.run([
+      {
+        root,
+        urlPrefix: 'docs',
+        urlSchema: 'manual',
+        pattern: '**/*.md',
+      },
+    ]);
+  });
+
+  test('sections should be ordered by order value first, then alphabetically', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const sectionNames = docs?.children.map((child) => child.name);
+
+    // category2 (order: 1) should come first
+    // category1 (order: 2) should come second
+    // test-custom (no order) should come after, alphabetically
+    expect(sectionNames).toEqual([
+      'category2',
+      'category1',
+      'test-custom',
+    ]);
+  });
+
+  test('sections should use custom labels from sections config', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const category1 = docs?.children.find((child) => child.name === 'category1');
+    const category2 = docs?.children.find((child) => child.name === 'category2');
+
+    expect(category1?.label).toBe('Category 1');
+    expect(category2?.label).toBe('Category 2');
+  });
+
+  test('sections without config should use folder name as label', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const testCustom = docs?.children.find((child) => child.name === 'test-custom');
+
+    expect(testCustom?.label).toBe('test-custom');
+  });
+});
+
+describe('Backward compatibility with labels config', () => {
+  let result: DocfyResult;
+
+  beforeAll(async () => {
+    const docfy = new Docfy({
+      labels: {
+        category1: 'Category One',
+        category2: 'Category Two',
+      },
+    });
+    result = await docfy.run([
+      {
+        root,
+        urlPrefix: 'docs',
+        urlSchema: 'manual',
+        pattern: '**/*.md',
+      },
+    ]);
+  });
+
+  test('labels config should still work for custom labels', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const category1 = docs?.children.find((child) => child.name === 'category1');
+    const category2 = docs?.children.find((child) => child.name === 'category2');
+
+    expect(category1?.label).toBe('Category One');
+    expect(category2?.label).toBe('Category Two');
+  });
+
+  test('sections should be alphabetically sorted when using labels config', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const sectionNames = docs?.children.map((child) => child.name);
+
+    // All sections should be alphabetically sorted by label
+    expect(sectionNames).toEqual([
+      'category1', // "Category One"
+      'category2', // "Category Two"
+      'test-custom', // "test-custom"
+    ]);
+  });
+});
+
+describe('Sections config takes precedence over labels config', () => {
+  let result: DocfyResult;
+
+  beforeAll(async () => {
+    const docfy = new Docfy({
+      labels: {
+        category1: 'Old Label',
+      },
+      sections: {
+        category1: { label: 'New Label', order: 1 },
+      },
+    });
+    result = await docfy.run([
+      {
+        root,
+        urlPrefix: 'docs',
+        urlSchema: 'manual',
+        pattern: '**/*.md',
+      },
+    ]);
+  });
+
+  test('sections config should override labels config', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const category1 = docs?.children.find((child) => child.name === 'category1');
+
+    expect(category1?.label).toBe('New Label');
+  });
+});
+
+describe('Nested section ordering', () => {
+  let result: DocfyResult;
+
+  beforeAll(async () => {
+    const docfy = new Docfy({
+      sections: {
+        category1: { label: 'Category 1', order: 1 },
+        components: { label: 'UI Components', order: 1 },
+      },
+    });
+    result = await docfy.run([
+      {
+        root,
+        urlPrefix: 'docs',
+        urlSchema: 'manual',
+        pattern: '**/*.md',
+      },
+    ]);
+  });
+
+  test('nested sections should use sections config for labels and ordering', () => {
+    const docs = result.nestedPageMetadata.children.find((child) => child.name === 'docs');
+    expect(docs).toBeDefined();
+
+    const category1 = docs?.children.find((child) => child.name === 'category1');
+    expect(category1).toBeDefined();
+
+    // Check that the nested 'components' section uses the configured label
+    const components = category1?.children.find((child) => child.name === 'components');
+    expect(components?.label).toBe('UI Components');
+  });
+});

--- a/test-app-vite/app/components/sidebar-nav.gts
+++ b/test-app-vite/app/components/sidebar-nav.gts
@@ -83,93 +83,93 @@ export default class SidebarNav extends Component<SidebarNavSignature> {
     >
       <nav class="font-light space-y-3">
         <ul class="space-y-3">
-        {{#each @node.pages as |page|}}
-          <li>
-            <DocfyLink
-              @to={{page.url}}
-              class="hover:text-green-800 dark-hover:text-green-500"
-              @activeClass="font-semibold text-green-800 dark:text-green-500"
-              {{on "click" this.handleSidebarClick}}
-            >
-              {{page.title}}
-            </DocfyLink>
-          </li>
-        {{/each}}
+          {{#each @node.pages as |page|}}
+            <li>
+              <DocfyLink
+                @to={{page.url}}
+                class="hover:text-green-800 dark-hover:text-green-500"
+                @activeClass="font-semibold text-green-800 dark:text-green-500"
+                {{on "click" this.handleSidebarClick}}
+              >
+                {{page.title}}
+              </DocfyLink>
+            </li>
+          {{/each}}
 
-        {{#each @node.children as |child|}}
-          <li>
-            <div class="pb-2">
-              {{child.label}}
-            </div>
+          {{#each @node.children as |child|}}
+            <li>
+              <div class="pb-2">
+                {{child.label}}
+              </div>
 
-            <ul
-              class="pl-6 border-l border-gray-400 dark:border-gray-700 space-y-3"
-            >
-              {{#each child.pages as |page|}}
-                <li class="truncate">
-                  <DocfyLink
-                    @to={{page.url}}
-                    class="hover:text-green-800 dark-hover:text-green-500"
-                    @activeClass="font-semibold text-green-800 dark:text-green-500"
-                    {{on "click" this.handleSidebarClick}}
-                  >
-                    {{page.title}}
-                  </DocfyLink>
-                </li>
-              {{/each}}
+              <ul
+                class="pl-6 border-l border-gray-400 dark:border-gray-700 space-y-3"
+              >
+                {{#each child.pages as |page|}}
+                  <li class="truncate">
+                    <DocfyLink
+                      @to={{page.url}}
+                      class="hover:text-green-800 dark-hover:text-green-500"
+                      @activeClass="font-semibold text-green-800 dark:text-green-500"
+                      {{on "click" this.handleSidebarClick}}
+                    >
+                      {{page.title}}
+                    </DocfyLink>
+                  </li>
+                {{/each}}
 
-              {{#each child.children as |subChild|}}
-                <li>
-                  <div class="pb-2">
-                    {{subChild.label}}
-                  </div>
+                {{#each child.children as |subChild|}}
+                  <li>
+                    <div class="pb-2">
+                      {{subChild.label}}
+                    </div>
 
-                  <ul
-                    class="pl-6 border-l border-gray-400 dark:border-gray-700 space-y-3"
-                  >
-                    {{#each subChild.pages as |page|}}
-                      <li class="truncate">
-                        <DocfyLink
-                          @to={{page.url}}
-                          class="hover:text-green-800 dark-hover:text-green-500"
-                          @activeClass="font-semibold text-green-800 dark:text-green-500"
-                          {{on "click" this.handleSidebarClick}}
-                        >
-                          {{page.title}}
-                        </DocfyLink>
-                      </li>
-                    {{/each}}
+                    <ul
+                      class="pl-6 border-l border-gray-400 dark:border-gray-700 space-y-3"
+                    >
+                      {{#each subChild.pages as |page|}}
+                        <li class="truncate">
+                          <DocfyLink
+                            @to={{page.url}}
+                            class="hover:text-green-800 dark-hover:text-green-500"
+                            @activeClass="font-semibold text-green-800 dark:text-green-500"
+                            {{on "click" this.handleSidebarClick}}
+                          >
+                            {{page.title}}
+                          </DocfyLink>
+                        </li>
+                      {{/each}}
 
-                    {{#each subChild.children as |subSubChild|}}
-                      <li>
-                        <div class="pb-2">
-                          {{subSubChild.label}}
-                        </div>
+                      {{#each subChild.children as |subSubChild|}}
+                        <li>
+                          <div class="pb-2">
+                            {{subSubChild.label}}
+                          </div>
 
-                        <ul
-                          class="pl-6 border-l border-gray-400 dark:border-gray-700 space-y-3"
-                        >
-                          {{#each subSubChild.pages as |page|}}
-                            <li class="truncate">
-                              <DocfyLink
-                                @to={{page.url}}
-                                class="hover:text-green-800 dark-hover:text-green-500"
-                                @activeClass="font-semibold text-green-800 dark:text-green-500"
-                                {{on "click" this.handleSidebarClick}}
-                              >
-                                {{page.title}}
-                              </DocfyLink>
-                            </li>
-                          {{/each}}
-                        </ul>
-                      </li>
-                    {{/each}}
-                  </ul>
-                </li>
-              {{/each}}
-            </ul>
-          </li>
-        {{/each}}
+                          <ul
+                            class="pl-6 border-l border-gray-400 dark:border-gray-700 space-y-3"
+                          >
+                            {{#each subSubChild.pages as |page|}}
+                              <li class="truncate">
+                                <DocfyLink
+                                  @to={{page.url}}
+                                  class="hover:text-green-800 dark-hover:text-green-500"
+                                  @activeClass="font-semibold text-green-800 dark:text-green-500"
+                                  {{on "click" this.handleSidebarClick}}
+                                >
+                                  {{page.title}}
+                                </DocfyLink>
+                              </li>
+                            {{/each}}
+                          </ul>
+                        </li>
+                      {{/each}}
+                    </ul>
+                  </li>
+                {{/each}}
+              </ul>
+            </li>
+          {{/each}}
         </ul>
       </nav>
     </div>

--- a/test-app-vite/docfy.config.mjs
+++ b/test-app-vite/docfy.config.mjs
@@ -29,10 +29,10 @@ export default {
       urlPrefix: 'docs',
     },
   ],
-  labels: {
-    components: 'Components',
-    core: '@docfy/core',
-    ember: 'Ember',
-    docs: 'Documentation',
+  sections: {
+    docs: { label: 'Documentation', order: 1 },
+    components: { label: 'Components', order: 2 },
+    core: { label: '@docfy/core', order: 3 },
+    ember: { label: 'Ember', order: 4 },
   },
 };

--- a/test-app-vite/tests/integration/components/docs-layout-test.gts
+++ b/test-app-vite/tests/integration/components/docs-layout-test.gts
@@ -258,7 +258,9 @@ module('Integration | Component | @docfy/docs-layout', function (hooks) {
       assert.dom('div.markdown').exists();
 
       // Verify the service exists and can be called
-      assert.ok(typeof currentHeadingService.setCurrentHeadingId === 'function');
+      assert.ok(
+        typeof currentHeadingService.setCurrentHeadingId === 'function'
+      );
     } finally {
       document.body.removeChild(mockHeading);
     }


### PR DESCRIPTION
## Summary

This PR adds the ability to order documentation sections (folders) using a new `sections` configuration option. Previously, sections could only be ordered alphabetically. Now users can control both the display order and custom labels for documentation sections.

## Changes

### Core Features
- **New `sections` config**: Allows configuring section labels and order
  ```js
  sections: {
    'getting-started': { label: 'Getting Started', order: 1 },
    api: { label: 'API Reference', order: 2 },
    guides: { label: 'Guides', order: 3 }
  }
  ```
- **Smart ordering**: Sections with `order` are sorted numerically, sections without are sorted alphabetically
- **Nested support**: Configuration applies to all nesting levels
- **Backward compatible**: Existing `labels` config continues to work (now deprecated)

### Implementation
- Added `SectionConfig` interface with `label` and `order` properties
- Updated `nested-page-metadata.ts` sorting logic to support custom ordering
- Helper functions for label and order resolution with fallback to legacy `labels`
- Sections config takes precedence when both `sections` and `labels` are defined

### Testing
- Added comprehensive test suite (`section-ordering.test.ts`) with 7 new tests:
  - Section ordering behavior
  - Custom labels
  - Backward compatibility with `labels` config
  - Precedence when both configs exist
  - Nested section configuration
- All 57 tests pass (50 existing + 7 new)

### Documentation
- Updated `docs/configuration.md` with full documentation
- Added examples and usage patterns
- Marked `labels` as deprecated with migration guidance
- Updated example config in `test-app-vite/docfy.config.mjs`

## Migration Path

Existing projects using `labels` will continue to work without changes. To adopt the new feature:

```js
// Before (still works)
labels: {
  components: 'Components',
  api: 'API Reference'
}

// After (recommended)
sections: {
  components: { label: 'Components', order: 2 },
  api: { label: 'API Reference', order: 1 }
}
```

## Test Plan
- ✅ All existing tests pass
- ✅ New tests verify ordering behavior
- ✅ Backward compatibility confirmed
- ✅ Nested sections tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)