### PR TITLE
fix(ember): don't resolve the target route to render a DocfyLink

### DIFF
--- a/packages/ember/src/components/docfy-link.gts
+++ b/packages/ember/src/components/docfy-link.gts
@@ -18,20 +18,42 @@ interface DocfyLinkSignature {
   };
 }
 
+/** Drop a trailing slash and any query string, so URLs compare by path. */
+function normalizePath(url: string): string {
+  const path = url.split(/[?#]/)[0] ?? '';
+
+  return path.length > 1 ? path.replace(/\/+$/, '') : path;
+}
+
+/**
+ * A link to a Docfy page.
+ *
+ * Docfy addresses pages by URL, and `@to` is already the router's path, so
+ * neither the href nor the active state needs the target route resolved.
+ *
+ * That matters under Embroider's `splitAtRoutes`: `RouterService#recognize()`
+ * resolves the matched route handlers, and resolving a route inside a split
+ * bundle makes `@embroider/router` fetch that bundle. Calling it from a getter
+ * meant that merely rendering a link downloaded the page it pointed at, so a
+ * page linking to every section pulled the whole documentation site up front.
+ * Recognition now happens in `navigate`, where the bundle is about to be needed
+ * anyway.
+ */
 export default class DocfyLink extends Component<DocfyLinkSignature> {
   @service('router') declare router: RouterService;
 
-  get routeName(): string | undefined {
-    const { to } = this.args;
-
-    return this.router.recognize(to)?.name;
+  /**
+   * `@to` as the router would produce it. Docfy gives index pages a trailing
+   * slash (`/docs/getting-started/`) where `urlFor` did not, so it is dropped
+   * here to keep the rendered href unchanged.
+   */
+  get path(): string {
+    return normalizePath(this.args.to);
   }
 
   get href(): string {
-    let url = this.args.to;
-    if (this.routeName) {
-      url = this.router.urlFor(this.routeName);
-    }
+    const rootURL = this.router.rootURL?.replace(/\/+$/, '') ?? '';
+    const url = `${rootURL}${this.path}`;
 
     if (this.args.anchor) {
       return `${url}#${this.args.anchor}`;
@@ -41,7 +63,21 @@ export default class DocfyLink extends Component<DocfyLinkSignature> {
   }
 
   get isActive(): boolean {
-    return this.router.currentRouteName === this.routeName;
+    const { currentURL } = this.router;
+
+    if (!currentURL) {
+      return false;
+    }
+
+    // `currentURL` is root-relative, but strip `rootURL` defensively so this
+    // holds however the router reports it.
+    const rootURL = this.router.rootURL?.replace(/\/+$/, '') ?? '';
+    const current =
+      rootURL && currentURL.startsWith(rootURL)
+        ? currentURL.slice(rootURL.length)
+        : currentURL;
+
+    return normalizePath(current) === this.path;
   }
 
   @action
@@ -50,10 +86,17 @@ export default class DocfyLink extends Component<DocfyLinkSignature> {
       return;
     }
 
-    if (this.routeName && !this.args.anchor) {
-      event.preventDefault();
-      this.router.transitionTo(this.routeName);
+    if (this.args.anchor) {
+      return;
     }
+
+    // An unrecognised `@to` is left to the browser, as before.
+    if (!this.router.recognize(this.path)) {
+      return;
+    }
+
+    event.preventDefault();
+    this.router.transitionTo(this.path);
   }
 
   <template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,6 +963,9 @@ importers:
       remark-highlight.js:
         specifier: ^6.0.0
         version: 6.0.0
+      sinon:
+        specifier: ^22.1.0
+        version: 22.1.0
       tailwindcss:
         specifier: ^4.1.0
         version: 4.3.3
@@ -3026,8 +3029,14 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@sinonjs/fake-timers@15.4.0':
+    resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
+
   '@sinonjs/fake-timers@6.0.1':
     resolution: {integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==}
+
+  '@sinonjs/samsam@10.0.2':
+    resolution: {integrity: sha512-8lVwD1Df1BmzoaOLhMcGGcz/Jyr5QY2KSB75/YK1QgKzoabTeLdIVyhXNZK9ojfSKSdirbXqdbsXXqP9/Ve8+A==}
 
   '@sinonjs/samsam@5.3.1':
     resolution: {integrity: sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==}
@@ -3486,6 +3495,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -5154,6 +5164,10 @@ packages:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
 
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
+    engines: {node: '>=0.3.1'}
+
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
@@ -5716,6 +5730,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -9543,6 +9558,9 @@ packages:
   simple-swizzle@0.2.4:
     resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
+  sinon@22.1.0:
+    resolution: {integrity: sha512-n1ajF2rBWMTtEwbKcw4UdFg4nCnDdq/U6RDoxtOd7oapOlRoJ5ynwFx60owROyhDpA9QhMZi0pCO/xtmwFjG7w==}
+
   sinon@9.2.4:
     resolution: {integrity: sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==}
     deprecated: 16.1.1
@@ -13296,9 +13314,18 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sinonjs/fake-timers@15.4.0':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
   '@sinonjs/fake-timers@6.0.1':
     dependencies:
       '@sinonjs/commons': 1.8.6
+
+  '@sinonjs/samsam@10.0.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
 
   '@sinonjs/samsam@5.3.1':
     dependencies:
@@ -15829,6 +15856,8 @@ snapshots:
   diff@4.0.4: {}
 
   diff@7.0.0: {}
+
+  diff@9.0.0: {}
 
   dlv@1.1.3: {}
 
@@ -22384,6 +22413,13 @@ snapshots:
   simple-swizzle@0.2.4:
     dependencies:
       is-arrayish: 0.3.4
+
+  sinon@22.1.0:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 15.4.0
+      '@sinonjs/samsam': 10.0.2
+      diff: 9.0.0
 
   sinon@9.2.4:
     dependencies:

--- a/test-app-vite/package.json
+++ b/test-app-vite/package.json
@@ -89,6 +89,7 @@
     "remark-autolink-headings": "^6.0.0",
     "remark-code-import": "^0.2.0",
     "remark-highlight.js": "^6.0.0",
+    "sinon": "^22.1.0",
     "tailwindcss": "^4.1.0",
     "testem": "^3.16.0",
     "tracked-built-ins": "^4.0.0",

--- a/test-app-vite/tests/integration/components/docfy-link-test.gts
+++ b/test-app-vite/tests/integration/components/docfy-link-test.gts
@@ -1,0 +1,166 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click } from '@ember/test-helpers';
+import DocfyLink from '@docfy/ember/components/docfy-link';
+import type RouterService from '@ember/routing/router-service';
+
+interface RouterStub {
+  recognizeCalls: string[];
+  transitions: string[];
+}
+
+/**
+ * Replace the router service's URL-resolving surface.
+ *
+ * `recognize` is the interesting one: under Embroider's `splitAtRoutes` it
+ * resolves the target route, which fetches that route's bundle. These tests
+ * assert it is never reached while rendering.
+ */
+function stubRouter(
+  owner: { lookup(name: string): unknown },
+  { currentURL = '/docs/other', recognizes = true } = {}
+): RouterStub {
+  const router = owner.lookup('service:router') as RouterService;
+  const stub: RouterStub = { recognizeCalls: [], transitions: [] };
+
+  Object.defineProperty(router, 'currentURL', {
+    value: currentURL,
+    configurable: true,
+  });
+  Object.defineProperty(router, 'rootURL', { value: '/', configurable: true });
+
+  router.recognize = ((url: string) => {
+    stub.recognizeCalls.push(url);
+    return recognizes ? ({ name: 'docs.configuration' } as never) : undefined;
+  }) as RouterService['recognize'];
+
+  router.transitionTo = ((url: string) => {
+    stub.transitions.push(url);
+    return undefined as never;
+  }) as RouterService['transitionTo'];
+
+  return stub;
+}
+
+module('Integration | Component | DocfyLink', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('the href comes from @to, without resolving the route', async function (assert) {
+    const router = stubRouter(this.owner);
+
+    await render(
+      <template><DocfyLink @to="/docs/configuration">Config</DocfyLink></template>
+    );
+
+    assert
+      .dom('[data-test-docfy-link]')
+      .hasAttribute('href', '/docs/configuration');
+    assert.deepEqual(
+      router.recognizeCalls,
+      [],
+      'recognize() is not called while rendering'
+    );
+  });
+
+  test('an index page URL does not render a trailing slash', async function (assert) {
+    stubRouter(this.owner);
+
+    // Docfy gives index pages a trailing slash; urlFor never produced one.
+    await render(
+      <template><DocfyLink @to="/docs/getting-started/">Start</DocfyLink></template>
+    );
+
+    assert
+      .dom('[data-test-docfy-link]')
+      .hasAttribute('href', '/docs/getting-started');
+  });
+
+  test('an anchor is appended to the href', async function (assert) {
+    stubRouter(this.owner);
+
+    await render(
+      <template>
+        <DocfyLink @to="/docs/configuration" @anchor="urlschema">Schema</DocfyLink>
+      </template>
+    );
+
+    assert
+      .dom('[data-test-docfy-link]')
+      .hasAttribute('href', '/docs/configuration#urlschema');
+  });
+
+  test('active state is derived from the current URL', async function (assert) {
+    const router = stubRouter(this.owner, {
+      currentURL: '/docs/configuration',
+    });
+
+    await render(
+      <template>
+        <DocfyLink @to="/docs/configuration" @activeClass="is-active">
+          Config
+        </DocfyLink>
+      </template>
+    );
+
+    assert.dom('[data-test-docfy-link]').hasClass('is-active');
+    assert
+      .dom('[data-test-docfy-link]')
+      .hasAttribute('data-test-is-active', 'true');
+    assert.deepEqual(router.recognizeCalls, [], 'still no route resolution');
+  });
+
+  test('an index page is active when visited without its trailing slash', async function (assert) {
+    stubRouter(this.owner, { currentURL: '/docs/getting-started' });
+
+    await render(
+      <template>
+        <DocfyLink @to="/docs/getting-started/" @activeClass="is-active">
+          Start
+        </DocfyLink>
+      </template>
+    );
+
+    assert.dom('[data-test-docfy-link]').hasClass('is-active');
+  });
+
+  test('an unrelated current URL is not active', async function (assert) {
+    stubRouter(this.owner);
+
+    await render(
+      <template>
+        <DocfyLink @to="/docs/configuration" @activeClass="is-active">
+          Config
+        </DocfyLink>
+      </template>
+    );
+
+    assert.dom('[data-test-docfy-link]').doesNotHaveClass('is-active');
+  });
+
+  test('clicking resolves the route and transitions', async function (assert) {
+    const router = stubRouter(this.owner);
+
+    await render(
+      <template><DocfyLink @to="/docs/configuration">Config</DocfyLink></template>
+    );
+    await click('[data-test-docfy-link]');
+
+    assert.deepEqual(
+      router.recognizeCalls,
+      ['/docs/configuration'],
+      'resolved on click, not on render'
+    );
+    assert.deepEqual(router.transitions, ['/docs/configuration']);
+  });
+
+  test('an unrecognised @to is left to the browser', async function (assert) {
+    const router = stubRouter(this.owner, { recognizes: false });
+
+    await render(
+      <template><DocfyLink @to="/not-a-page">Nope</DocfyLink></template>
+    );
+    await click('[data-test-docfy-link]');
+
+    assert.deepEqual(router.transitions, [], 'no transition is attempted');
+  });
+});


### PR DESCRIPTION
Makes `<DocfyLink>` compatible with Embroider's `splitAtRoutes`.

## The problem

`RouterService#recognize()` resolves the matched route handlers, and resolving a route that lives inside a split bundle is what makes `@embroider/router` fetch that bundle. `DocfyLink` called it from its `routeName` getter, which both `href` and `isActive` read — so **merely rendering a link downloaded the page it pointed at.**

A docs sidebar or homepage that links across every section therefore pulled the entire documentation site up front, which defeats the split. Traced with a stack:

```
get href → get routeName → RouterService#recognize → applyToState → get route → getRoute → fetch bundle
```

This is specific to resolving a *URL*, which is how Docfy addresses pages. Plain `<LinkTo @route="...">` is unaffected — it is addressed by route name, needs no `recognize()`, and renders the same href without loading anything.

Worth noting `@embroider/router`'s README documents the opposite intent: it declines to support `Route#serialize` precisely so that "linking to a route" need not load it, and `_getQPMeta` is overridden with a comment about avoiding "premature loading of lazy routes when we are merely trying to render a link-to". `recognize()` looks like an unguarded path in that same story, but the practical fix belongs here, where the URL-addressing happens.

## The change

`@to` is already the router's path, so nothing needs resolving to render:

- `href` is built from `router.rootURL` + `@to`
- `isActive` compares `router.currentURL` instead of route names
- `recognize()` moves into `navigate()`, where the bundle is about to be loaded anyway

An unrecognised `@to` still falls through to the browser, and `@anchor` links are still left alone, both as before.

**One behaviour difference needed handling.** Docfy gives index pages a trailing slash (`/docs/getting-started/`) where `urlFor` never rendered one, so building `href` straight from `@to` would have changed every index link to a trailing-slash URL. On hosts with "pretty URLs" (Netlify, for one) that is a 301 on every cold page load, and it moves a site's canonical URLs. The path is normalised so hrefs stay byte-identical. There is a test for it.

## Measured

Verified against a real `splitAtRoutes` app ([frontile.dev](https://frontile.dev)'s docs site) by linking it at this build. Homepage, which links to ~40 docs pages across every section:

| | stock | this PR | app-local workaround |
|---|---|---|---|
| Split route chunks fetched on `/` | **3** | **0** | 0 |
| Homepage JS (uncompressed) | 2146 kB | **932 kB** | 913 kB |

Navigation still works: clicking transitions client-side, the URL/title/heading update, and exactly one chunk loads on demand.

(The third column is a hand-rolled link component that app added to work around this. With this fix it can delete it, which is the point.)

## Testing caveat, please read

`DocfyLink` had no component tests, so this adds 8 integration tests covering href construction, the trailing-slash case, anchors, active state, click-through, and the unrecognised-URL fallback.

**I was unable to run them: `test-app-vite`'s suite is already broken on `main`.** `vite build` fails to resolve `sinon`, which three existing tests (`docs-layout-test`, `page-headings-test`, `intersect-headings-test`) import without it being declared in `test-app-vite/package.json`. Adding it gets past that and into a second pre-existing failure — `ReferenceError: define is not defined` from `@embroider/virtual/test-support.js`. Both reproduce on a clean `main` checkout.

So this PR includes `sinon` as a `test-app-vite` devDependency (it is genuinely missing), but the new tests are **unverified**, and the `define` problem is left alone as out of scope. The component change itself is verified in the real app above. Happy to split the dependency fix out, or to look at the test harness separately if you want it in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
