### PR TITLE
chore: stop linting compiled output with prettier

### DIFF
--- a/packages/core/.prettierignore
+++ b/packages/core/.prettierignore
@@ -1,0 +1,5 @@
+# compiled output
+/lib/
+
+# misc
+pnpm-lock.yaml

--- a/packages/ember-cli/.prettierignore
+++ b/packages/ember-cli/.prettierignore
@@ -1,0 +1,5 @@
+# compiled output
+/lib/
+
+# misc
+pnpm-lock.yaml

--- a/packages/ember-cli/ember-cli-build.js
+++ b/packages/ember-cli/ember-cli-build.js
@@ -5,7 +5,6 @@ process.env.EXPERIMENTAL_RENDER_MODE_SERIALIZE = true;
 
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
-
 module.exports = function (defaults) {
   const trees = {};
   // Exclude FastBoot tests if FASTBOOT_DISABLED is set,

--- a/packages/ember-vite/.prettierignore
+++ b/packages/ember-vite/.prettierignore
@@ -1,0 +1,5 @@
+# compiled output
+/dist/
+
+# misc
+pnpm-lock.yaml

--- a/packages/plugin-with-prose/.prettierignore
+++ b/packages/plugin-with-prose/.prettierignore
@@ -1,0 +1,5 @@
+# compiled output
+/lib/
+
+# misc
+pnpm-lock.yaml

--- a/test-app-vite/tests/integration/components/docfy-link-test.gts
+++ b/test-app-vite/tests/integration/components/docfy-link-test.gts
@@ -49,7 +49,9 @@ module('Integration | Component | DocfyLink', function (hooks) {
     const router = stubRouter(this.owner);
 
     await render(
-      <template><DocfyLink @to="/docs/configuration">Config</DocfyLink></template>
+      <template>
+        <DocfyLink @to="/docs/configuration">Config</DocfyLink>
+      </template>
     );
 
     assert
@@ -67,7 +69,9 @@ module('Integration | Component | DocfyLink', function (hooks) {
 
     // Docfy gives index pages a trailing slash; urlFor never produced one.
     await render(
-      <template><DocfyLink @to="/docs/getting-started/">Start</DocfyLink></template>
+      <template>
+        <DocfyLink @to="/docs/getting-started/">Start</DocfyLink>
+      </template>
     );
 
     assert
@@ -80,7 +84,10 @@ module('Integration | Component | DocfyLink', function (hooks) {
 
     await render(
       <template>
-        <DocfyLink @to="/docs/configuration" @anchor="urlschema">Schema</DocfyLink>
+        <DocfyLink
+          @to="/docs/configuration"
+          @anchor="urlschema"
+        >Schema</DocfyLink>
       </template>
     );
 
@@ -141,7 +148,9 @@ module('Integration | Component | DocfyLink', function (hooks) {
     const router = stubRouter(this.owner);
 
     await render(
-      <template><DocfyLink @to="/docs/configuration">Config</DocfyLink></template>
+      <template>
+        <DocfyLink @to="/docs/configuration">Config</DocfyLink>
+      </template>
     );
     await click('[data-test-docfy-link]');
 
@@ -157,7 +166,9 @@ module('Integration | Component | DocfyLink', function (hooks) {
     const router = stubRouter(this.owner, { recognizes: false });
 
     await render(
-      <template><DocfyLink @to="/not-a-page">Nope</DocfyLink></template>
+      <template>
+        <DocfyLink @to="/not-a-page">Nope</DocfyLink>
+      </template>
     );
     await click('[data-test-docfy-link]');
 

--- a/test-app-vite/vite.config.mjs
+++ b/test-app-vite/vite.config.mjs
@@ -18,7 +18,7 @@ export default defineConfig({
           projectDescription:
             'Docfy is a modular JavaScript tool to help build documentation sites.',
         },
-      }
+      },
     ),
     tailwindcss(),
     classicEmberSupport(),


### PR DESCRIPTION
Found while working on #215. `pnpm lint:format` is red on a clean checkout.

## Cause

Four packages have no `.prettierignore`, so `prettier .` walks their build output:

| package | flagged |
|---|---|
| `@docfy/core` | 27 files in `lib/` |
| `@docfy/ember-vite` | 32 files in `dist/` |
| `@docfy/ember-cli` | 17 files in `lib/` |
| `@docfy/plugin-with-prose` | 2 files in `lib/` |
| `@docfy/ember` | none — it already has a `.prettierignore` |

Nobody hits this because CI has its lint step commented out, and `lint:format` isn't part of the `lint` script.

## Fix

Adds `.prettierignore` to the four packages missing one, modelled on the one `@docfy/ember` already had.

With the generated noise gone, three genuinely unformatted **source** files were left over:

- `packages/ember-cli/ember-cli-build.js`
- `test-app-vite/vite.config.mjs`
- `test-app-vite/tests/integration/components/docfy-link-test.gts`

I owe an admission on those: I saw exactly these diffs during #213, assumed they were churn from a prettier version difference, and reverted them. They were real formatting fixes, so they're applied here.

`pnpm lint:format` now passes across the whole workspace — a prerequisite for re-enabling that commented-out lint step in CI, which is worth doing separately (`packages/ember` `lint:hbs` and both test apps' `lint:types` are currently red for unrelated reasons: nested splattributes, and `@glint/core` not being a dependency of `test-app-classic`).

Verified: `pnpm -r run compile` clean, `vite build` succeeds and still emits Docfy routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
