### PR TITLE
chore: type the workspace against @types/unist v3 and real mdast/hast

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "@types/hosted-git-info": "^3.0.5",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.0.14",
-    "@types/unist": "^2.0.0",
+    "@types/unist": "^3.0.0",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-n": "^17.18.0",

--- a/packages/core/src/-private/utils.ts
+++ b/packages/core/src/-private/utils.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { visit } from 'unist-util-visit';
-import { Node } from 'unist';
+import type { Node } from 'unist';
+import type { Root as MdastRoot } from 'mdast';
 import { toString } from 'mdast-util-to-string';
 import { slug } from 'github-slugger';
 import url from 'url';
@@ -73,11 +74,10 @@ export function generateAutoUrl(source: string, prefix?: string, suffix?: string
   return clearURL(parts, ignoreSuffix ? '' : suffix || '');
 }
 
-export function inferTitle(ast: Node): string | undefined {
+export function inferTitle(ast: MdastRoot): string | undefined {
   let docTitle: string | undefined;
   visit(ast, 'heading', node => {
-    const { depth } = node as never;
-    if (depth !== 1) return;
+    if (node.depth !== 1) return;
     docTitle = toString(node);
   });
   return docTitle;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ import { getRepoEditUrl } from './-private/repo-info.js';
 import { transformToNestedPageMetadata } from './-private/nested-page-metadata.js';
 import debugFactory from 'debug';
 import type { Root as MdastRoot } from 'mdast';
+import type { Root as HastRoot } from 'hast';
 const debug = debugFactory('@docfy/core');
 
 class Docfy {
@@ -87,7 +88,10 @@ class Docfy {
           reject(err);
         } else {
           resolve({
-            content: ctx.pages,
+            // The pipeline holds `Context<PageAST>` because `page.ast` changes
+            // shape half-way through it. By the time it resolves,
+            // `transformerMdastToHast` has replaced every tree with hast.
+            content: ctx.pages as PageContent<HastRoot>[],
             staticAssets: ctx.staticAssets,
             nestedPageMetadata: transformToNestedPageMetadata(
               ctx.pages.map(p => p.meta),
@@ -101,6 +105,11 @@ class Docfy {
     });
   }
 
+  /*
+   * Turns every page's mdast tree into a hast tree. This is the point where
+   * `PageContent.ast` switches from `mdast.Root` to `hast.Root`, which is why
+   * the pipeline is typed with the union of both and narrows here.
+   */
   private transformerMdastToHast(ctx: Context): void {
     ctx.pages.forEach(page => {
       page.ast = ctx.rehype.runSync(page.ast as MdastRoot, page.vFile);

--- a/packages/core/src/plugins/render-markdown.ts
+++ b/packages/core/src/plugins/render-markdown.ts
@@ -1,6 +1,5 @@
 import plugin from '../plugin.js';
 import stringify from 'rehype-stringify';
-import type { Root as HastRoot } from 'hast';
 
 export default plugin({
   runAfter(context): void {
@@ -9,9 +8,9 @@ export default plugin({
     });
 
     context.pages.forEach(page => {
-      page.rendered = rehype.stringify(page.ast as HastRoot);
+      page.rendered = rehype.stringify(page.ast);
       page.demos?.forEach(demo => {
-        demo.rendered = rehype.stringify(demo.ast as HastRoot);
+        demo.rendered = rehype.stringify(demo.ast);
       });
     });
   },

--- a/packages/core/src/plugins/replace-internal-links.ts
+++ b/packages/core/src/plugins/replace-internal-links.ts
@@ -1,32 +1,15 @@
 import path from 'path';
 import plugin from '../plugin.js';
-import { Node } from 'unist';
 import { visit } from 'unist-util-visit';
 import { isValidUrl, isAnchorUrl } from '../-private/utils.js';
 import { PageContent, Context } from '../types.js';
+import type { Root as MdastRoot, Definition, Link } from 'mdast';
 
-interface Resource {
-  url: string;
-  title?: string;
-}
-interface Association {
-  identifier: string;
-  label?: string;
-}
-
-interface LinkNode extends Node, Resource {
-  type: 'link';
-}
-
-interface LinkReferenceNode extends Node, Association {
-  type: 'linkReference';
-}
-
-interface DefinitionNode extends Node, Resource, Association {
-  type: 'definition';
-}
-
-function replaceURL(ctx: Context, page: PageContent, node: LinkNode | DefinitionNode): void {
+function replaceURL(
+  ctx: Context<MdastRoot>,
+  page: PageContent<MdastRoot>,
+  node: Link | Definition
+): void {
   if (isValidUrl(node.url) || isAnchorUrl(node.url)) {
     return;
   }
@@ -51,25 +34,19 @@ function replaceURL(ctx: Context, page: PageContent, node: LinkNode | Definition
   }
 }
 
-function isReferenceLink(node: LinkNode | LinkReferenceNode): node is LinkReferenceNode {
-  return node.type === 'linkReference';
-}
+function visitor(ctx: Context<MdastRoot>, page: PageContent<MdastRoot>): void {
+  const definitions: Record<string, Definition> = {};
 
-function visitor(ctx: Context, page: PageContent): void {
-  const definitions: Record<string, DefinitionNode> = {};
-
-  visit(page.ast, 'definition', (node: DefinitionNode) => {
+  visit(page.ast, 'definition', node => {
     definitions[node.identifier] = node;
   });
 
-  visit(page.ast, ['link', 'linkReference'], visited => {
-    const node = visited as unknown as LinkNode | LinkReferenceNode;
-
-    if (isReferenceLink(node)) {
+  visit(page.ast, ['link', 'linkReference'], node => {
+    if (node.type === 'linkReference') {
       if (definitions[node.identifier]) {
         replaceURL(ctx, page, definitions[node.identifier]);
       }
-    } else {
+    } else if (node.type === 'link') {
       replaceURL(ctx, page, node);
     }
   });

--- a/packages/core/src/plugins/static-assets.ts
+++ b/packages/core/src/plugins/static-assets.ts
@@ -2,33 +2,8 @@ import { visit } from 'unist-util-visit';
 import plugin from '../plugin.js';
 import { PageContent } from '../types.js';
 import { isValidUrl } from '../-private/utils.js';
-import { Node } from 'unist';
 import path from 'path';
-
-interface Resource {
-  url: string;
-  title?: string;
-}
-interface Association {
-  identifier: string;
-  label?: string;
-}
-
-interface ImageReferenceNode extends Node, Association {
-  type: 'imageReference';
-}
-
-interface DefinitionNode extends Node, Resource, Association {
-  type: 'definition';
-}
-
-interface ImageNode extends Node, Resource {
-  type: 'image';
-}
-
-function isImageReference(node: ImageNode | ImageReferenceNode): node is ImageReferenceNode {
-  return node.type === 'imageReference';
-}
+import type { Root as MdastRoot, Definition, Image } from 'mdast';
 
 function generateUniqueFileName(seen: string[], name: string, count?: number): string {
   if (seen.indexOf(name) == -1) {
@@ -56,7 +31,7 @@ export default plugin({
 
     const assets: Record<string, string> = {};
 
-    function transform(page: PageContent, node: DefinitionNode | ImageNode): void {
+    function transform(page: PageContent<MdastRoot>, node: Definition | Image): void {
       if (!isValidUrl(node.url) && !path.isAbsolute(node.url)) {
         const absolutePath = path.resolve(
           path.join(page.sourceConfig.root, path.dirname(page.source)),
@@ -79,20 +54,18 @@ export default plugin({
     }
 
     ctx.pages.forEach(page => {
-      const definitions: Record<string, DefinitionNode> = {};
+      const definitions: Record<string, Definition> = {};
 
-      visit(page.ast, 'definition', (node: DefinitionNode) => {
+      visit(page.ast, 'definition', node => {
         definitions[node.identifier] = node;
       });
 
-      visit(page.ast, ['image', 'imageReference'], visited => {
-        const node = visited as unknown as ImageNode | ImageReferenceNode;
-
-        if (isImageReference(node)) {
+      visit(page.ast, ['image', 'imageReference'], node => {
+        if (node.type === 'imageReference') {
           if (definitions[node.identifier]) {
             transform(page, definitions[node.identifier]);
           }
-        } else {
+        } else if (node.type === 'image') {
           transform(page, node);
         }
       });

--- a/packages/core/src/plugins/toc.ts
+++ b/packages/core/src/plugins/toc.ts
@@ -1,22 +1,17 @@
 import plugin from '../plugin.js';
 import { Heading } from '../types.js';
 import { visit } from 'unist-util-visit';
-import { Node, Parent } from 'unist';
 import { toString } from 'mdast-util-to-string';
 import { deleteNode } from '../-private/utils.js';
-
-interface HeadingNode extends Node {
-  depth: number;
-  data: {
-    id: string;
-    docfyDelete?: boolean;
-  };
-}
+import type { Heading as HeadingNode } from 'mdast';
 
 function getHeading(node: HeadingNode): Heading {
   return {
     title: toString(node),
-    id: node.data.id,
+    // `mdastSlug` runs on every tree before any plugin does, so `data.id` is
+    // always set by the time we get here. It is optional in the type because
+    // it is a Docfy augmentation of mdast's `HeadingData`.
+    id: node.data?.id as string,
     depth: node.depth,
   };
 }
@@ -38,31 +33,25 @@ function findParentOfDepth(headings: Heading[], depth: number): Heading[] {
   }
 }
 
-function isHeading(node: Node): node is HeadingNode {
-  return node.type === 'heading';
-}
-
 export default plugin({
   runWithMdast(ctx): void {
     ctx.pages.forEach((page): void => {
       const headings: Heading[] = [];
 
-      visit(page.ast, (node: Node, _, parentNode: Parent | undefined) => {
-        if (isHeading(node)) {
-          if (node.depth === 1) {
-            return;
-          }
+      visit(page.ast, 'heading', (node, _, parentNode) => {
+        if (node.depth === 1) {
+          return;
+        }
 
-          if (node.depth > ctx.options.tocMaxDepth) {
-            return;
-          }
-          const parent = findParentOfDepth(headings, node.depth);
+        if (node.depth > ctx.options.tocMaxDepth) {
+          return;
+        }
+        const parent = findParentOfDepth(headings, node.depth);
 
-          parent.push(getHeading(node));
+        parent.push(getHeading(node));
 
-          if (node.data.docfyDelete && parentNode) {
-            deleteNode(parentNode.children, node);
-          }
+        if (node.data?.docfyDelete && parentNode) {
+          deleteNode(parentNode.children, node);
         }
       });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Node as MarkdownAST } from 'unist';
 import { Processor, Plugin as UnifiedPlugin, Settings as UnifiedSettings } from 'unified';
 import { VFile } from 'vfile';
 import type { Root as MdastRoot } from 'mdast';
@@ -15,6 +14,30 @@ export type RemarkProcessor = Processor<MdastRoot, MdastRoot, MdastRoot, undefin
  * The HTML (hast) processor. Takes an mdast tree in and produces a hast tree.
  */
 export type RehypeProcessor = Processor<undefined, MdastRoot, HastRoot, undefined, undefined>;
+
+/**
+ * The tree a page holds. Docfy parses markdown into mdast, then transforms it
+ * to hast half-way through the pipeline, so which one `PageContent.ast` holds
+ * depends on when you look at it. See `Plugin` for the per-hook types.
+ */
+export type PageAST = MdastRoot | HastRoot;
+
+declare module 'mdast' {
+  interface HeadingData {
+    /**
+     * The slug of the heading, added by Docfy's `mdastSlug` transformer and
+     * read by the `toc` plugin.
+     */
+    id?: string | undefined;
+
+    /**
+     * Marks a heading to be removed from the tree by the `toc` plugin once it
+     * has been collected. The Ember integrations use it for demo titles, which
+     * belong in the table of contents but are rendered by `DocfyDemo` instead.
+     */
+    docfyDelete?: boolean | undefined;
+  }
+}
 
 export interface Heading {
   title: string;
@@ -35,15 +58,15 @@ export interface PageMetadata {
   parentLabel: undefined | string;
 }
 
-export interface PageContent {
+export interface PageContent<AST extends PageAST = PageAST> {
   meta: PageMetadata;
   sourceConfig: SourceConfig;
   source: string;
   vFile: VFile;
-  ast: MarkdownAST;
+  ast: AST;
   markdown: string;
   rendered: string;
-  demos?: PageContent[];
+  demos?: PageContent<AST>[];
   pluginData: Record<string, unknown>;
 }
 
@@ -59,10 +82,10 @@ export interface StaticAssetDefinition {
   toPath: string;
 }
 
-export interface Context {
+export interface Context<AST extends PageAST = PageAST> {
   remark: RemarkProcessor;
   rehype: RehypeProcessor;
-  pages: PageContent[];
+  pages: PageContent<AST>[];
   staticAssets: StaticAssetDefinition[];
   options: ContextOptions;
 }
@@ -75,7 +98,7 @@ export interface NestedPageMetadata {
 }
 
 export interface DocfyResult {
-  content: PageContent[];
+  content: PageContent<HastRoot>[];
   staticAssets: StaticAssetDefinition[];
   nestedPageMetadata: NestedPageMetadata;
 }
@@ -168,16 +191,22 @@ export interface PluginOptions {
   [key: string]: unknown;
 }
 
-export type PluginHandler<T = PluginOptions | undefined | null> = (
-  ctx: Context,
+export type PluginHandler<T = PluginOptions | undefined | null, AST extends PageAST = PageAST> = (
+  ctx: Context<AST>,
   options: T
 ) => void;
 
+/**
+ * Each hook is typed with the tree it actually receives: `runBefore` and
+ * `runWithMdast` run before Docfy transforms mdast to hast, `runWithHast` and
+ * `runAfter` run once the tree is hast. This means `page.ast` is a real
+ * `mdast.Root` or `hast.Root` inside a handler — no narrowing needed.
+ */
 export interface Plugin<T = PluginOptions | undefined | null> {
-  runBefore?: PluginHandler<T>;
-  runWithMdast?: PluginHandler<T>;
-  runWithHast?: PluginHandler<T>;
-  runAfter?: PluginHandler<T>;
+  runBefore?: PluginHandler<T, MdastRoot>;
+  runWithMdast?: PluginHandler<T, MdastRoot>;
+  runWithHast?: PluginHandler<T, HastRoot>;
+  runAfter?: PluginHandler<T, HastRoot>;
 }
 
 export interface PluginWithOptions<T = PluginOptions> extends Plugin<T> {

--- a/packages/ember-cli/package.json
+++ b/packages/ember-cli/package.json
@@ -49,8 +49,6 @@
     "ember-cli-htmlbars": "^6.3.0",
     "mdast-util-to-string": "^4.0.0",
     "remark-hbs": "^0.4.1",
-    "unist-builder": "^4.0.0",
-    "unist-util-find": "^3.0.0",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
@@ -64,7 +62,7 @@
     "@mapbox/rehype-prism": "^0.5.0",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
-    "@types/unist": "^2.0.0",
+    "@types/unist": "^3.0.0",
     "autoprefixer": "^10.4.21",
     "broccoli-asset-rev": "^3.0.0",
     "concurrently": "^9.1.2",

--- a/packages/ember-cli/src/plugins/escape-curlies-in-code.ts
+++ b/packages/ember-cli/src/plugins/escape-curlies-in-code.ts
@@ -1,7 +1,6 @@
 import plugin from '@docfy/core/lib/plugin.js';
 import { visit } from 'unist-util-visit';
-import type { Node } from 'unist';
-import type { Element, Text } from 'hast';
+import type { Root } from 'hast';
 import type { PageContent } from '@docfy/core/lib/types.js';
 
 /**
@@ -15,13 +14,13 @@ import type { PageContent } from '@docfy/core/lib/types.js';
  * bare `{{` into the output. Running at the hast stage (`runWithHast`, which
  * Docfy invokes after all rehype plugins) escapes the final text instead.
  */
-function escapeCurliesInCode(ast: Node): void {
-  visit(ast, 'element', (node: Element) => {
+function escapeCurliesInCode(ast: Root): void {
+  visit(ast, 'element', node => {
     if (node.tagName !== 'code') {
       return;
     }
 
-    visit(node, 'text', (textNode: Text) => {
+    visit(node, 'text', textNode => {
       textNode.value = textNode.value.replace(/\{\{/g, '\\{{');
     });
 
@@ -32,7 +31,7 @@ function escapeCurliesInCode(ast: Node): void {
 
 export default plugin({
   runWithHast(ctx): void {
-    const escape = (page: PageContent): void => {
+    const escape = (page: PageContent<Root>): void => {
       escapeCurliesInCode(page.ast);
       page.demos?.forEach(escape);
     };

--- a/packages/ember-cli/src/plugins/extract-demos-to-components.ts
+++ b/packages/ember-cli/src/plugins/extract-demos-to-components.ts
@@ -1,18 +1,18 @@
 import { visit } from 'unist-util-visit';
 import { Context, PageContent } from '@docfy/core/lib/types.js';
 import plugin from '@docfy/core/lib/plugin.js';
-import { Node, Parent } from 'unist';
-import { find as findNode } from 'unist-util-find';
 import { toString } from 'mdast-util-to-string';
-import { DemoComponent, DemoComponentChunk, CodeNode } from './types';
+import { DemoComponent, DemoComponentChunk } from './types';
 import {
   generateDemoComponentName,
   getExt,
   createDemoNodes,
   deleteNode,
+  findHeading,
   isDemoComponents,
 } from './utils';
 import path from 'path';
+import type { Heading, Paragraph, Root, RootContent } from 'mdast';
 
 /*
  * Create the heading for the examples section of the page.
@@ -22,85 +22,97 @@ import path from 'path';
  *
  * This is necessary for apps using remark-autolink-headings, for example.
  */
-function createHeading(ctx: Context): Node {
-  const heading = (ctx.remark.runSync(ctx.remark.parse('## Examples')).children as Node[])[0];
+function createHeading(ctx: Context<Root>): Heading {
+  // `## Examples` always parses to a single heading. Remark plugins in the
+  // stack can annotate it, but none of them replace it with another node type.
+  const heading = ctx.remark.runSync(ctx.remark.parse('## Examples')).children[0] as Heading;
   heading.depth = 2;
   return heading;
 }
 
-const isTextMarker = (node: Parent): boolean =>
-  node.type === 'paragraph' && node.children.length === 1 && node.children[0].type === 'text';
+/*
+ * Returns the text of a paragraph made up of a single text node, which is the
+ * shape every demo marker has.
+ */
+function markerText(node: Paragraph): string {
+  const child = node.children[0];
+  return node.children.length === 1 && child.type === 'text' ? child.value : '';
+}
 
 const demoMarkerRegex = /^\[\[demo:(.+?)\]\]$/;
-const demoMarker = (node: Parent): boolean =>
-  isTextMarker(node) && demoMarkerRegex.test(node.children[0].value as string);
+const demoMarker = (node: Paragraph): boolean => demoMarkerRegex.test(markerText(node));
 
 const demosAllMarkerRegex = /^\[\[demos-all\]\]$/;
-const demosAllMarker = (node: Parent): boolean =>
-  isTextMarker(node) && demosAllMarkerRegex.test(node.children[0].value as string);
+const demosAllMarker = (node: Paragraph): boolean => demosAllMarkerRegex.test(markerText(node));
+
+/*
+ * Replaces a demo marker paragraph with the given demo nodes.
+ *
+ * The paragraph is retyped to `div` so that `mdast-util-to-hast` falls back to
+ * its unknown-node handler and emits a plain `<div>`: a `<p>` cannot legally
+ * wrap the block-level markup being spliced in. Neither retyping a node nor
+ * putting block content inside a paragraph is expressible in mdast, so the
+ * marker is widened here.
+ */
+function replaceMarkerWithDemoNodes(marker: Paragraph, nodes: RootContent[]): void {
+  const container = marker as unknown as { type: string; children: RootContent[] };
+
+  container.type = 'div';
+  container.children.splice(0, 1, ...nodes);
+}
 
 /*
  * Insert Demo nodes into the page.
  */
-function insertDemoNodesIntoPage(page: PageContent, toInsert: Node[]): void {
-  if (Array.isArray(page.ast.children)) {
-    const secondHeading = findNode(
-      page.ast,
-      (node: Node) => node.type === 'heading' && node.depth !== 1
-    );
+function insertDemoNodesIntoPage(page: PageContent<Root>, toInsert: RootContent[]): void {
+  const secondHeading = findHeading(page.ast, node => node.depth !== 1);
 
-    if (secondHeading) {
-      const index = page.ast.children.findIndex(el => el === secondHeading);
-      page.ast.children.splice(index, 0, ...toInsert);
-    } else {
-      page.ast.children.push(...toInsert);
-    }
+  if (secondHeading) {
+    const index = page.ast.children.findIndex(el => el === secondHeading);
+    page.ast.children.splice(index, 0, ...toInsert);
+  } else {
+    page.ast.children.push(...toInsert);
   }
 }
 
-function replaceDemoMarkers(page: PageContent, demos: DemoComponent[]): void {
-  if (Array.isArray(page.ast.children)) {
-    const markers: Parent[] = [];
-    const allMarkers: Parent[] = [];
+function replaceDemoMarkers(page: PageContent<Root>, demos: DemoComponent[]): void {
+  const markers: Paragraph[] = [];
+  const allMarkers: Paragraph[] = [];
 
-    visit(page.ast, 'paragraph', (node: Parent) => {
-      if (demoMarker(node)) markers.push(node);
-      if (demosAllMarker(node)) allMarkers.push(node);
-    });
+  visit(page.ast, 'paragraph', node => {
+    if (demoMarker(node)) markers.push(node);
+    if (demosAllMarker(node)) allMarkers.push(node);
+  });
 
-    markers.forEach(marker => {
-      const child = marker.children[0];
-      const matches = (child.value as string).match(demoMarkerRegex);
-      if (!matches) return;
+  markers.forEach(marker => {
+    const matches = markerText(marker).match(demoMarkerRegex);
+    if (!matches) return;
 
-      // TODO: This is an inner loop and can cause perf issues if someone
-      // out there has many demos on a single page. It would be better to
-      // create a demo component hash that can be looked up by demo name.
-      const demoName = matches[1];
-      const demo = demos.find(d => d.name.dashCase.endsWith(demoName));
+    // TODO: This is an inner loop and can cause perf issues if someone
+    // out there has many demos on a single page. It would be better to
+    // create a demo component hash that can be looked up by demo name.
+    const demoName = matches[1];
+    const demo = demos.find(d => d.name.dashCase.endsWith(demoName));
 
-      if (!demo) {
-        console.warn(
-          `Found demo marker "${demoName}" with no matching demo component in ${page.source}`
-        );
-        return;
-      }
+    if (!demo) {
+      console.warn(
+        `Found demo marker "${demoName}" with no matching demo component in ${page.source}`
+      );
+      return;
+    }
 
-      marker.type = 'div';
-      marker.children.splice(0, 1, ...createDemoNodes(demo));
-    });
+    replaceMarkerWithDemoNodes(marker, createDemoNodes(demo));
+  });
 
-    allMarkers.forEach(marker => {
-      const demoNodes = demos.map(component => createDemoNodes(component)).flat();
+  allMarkers.forEach(marker => {
+    const demoNodes = demos.map(component => createDemoNodes(component)).flat();
 
-      marker.type = 'div';
-      marker.children.splice(0, 1, ...demoNodes);
-    });
-  }
+    replaceMarkerWithDemoNodes(marker, demoNodes);
+  });
 }
 
 export default plugin({
-  runWithMdast(ctx: Context): void {
+  runWithMdast(ctx): void {
     const seenNames: Set<string> = new Set();
 
     ctx.pages.forEach(page => {
@@ -110,7 +122,7 @@ export default plugin({
         page.demos.forEach(demo => {
           const chunks: DemoComponentChunk[] = [];
 
-          visit(demo.ast, 'code', (node: CodeNode) => {
+          visit(demo.ast, 'code', node => {
             if (['component', 'template', 'styles'].includes(node.meta || '')) {
               chunks.push({
                 snippet: node,
@@ -130,10 +142,7 @@ export default plugin({
             seenNames
           );
 
-          const demoTitle = findNode(
-            demo.ast,
-            (node: Node) => node.type === 'heading' && node.depth === 1
-          );
+          const demoTitle = findHeading(demo.ast, node => node.depth === 1);
 
           if (demoTitle) {
             demoTitle.depth = 3;
@@ -167,7 +176,7 @@ export default plugin({
         } else {
           // Automatic demo insertion creates an Example block after
           // the first heading.
-          const toInsert: Node[] = [createHeading(ctx)];
+          const toInsert: RootContent[] = [createHeading(ctx)];
           demoComponents.forEach(component => {
             toInsert.push(...createDemoNodes(component));
           });

--- a/packages/ember-cli/src/plugins/preview-template.ts
+++ b/packages/ember-cli/src/plugins/preview-template.ts
@@ -1,6 +1,6 @@
 import { visit } from 'unist-util-visit';
 import plugin from '@docfy/core/lib/plugin.js';
-import { DemoComponent, CodeNode } from './types';
+import { DemoComponent } from './types';
 import {
   generateDemoComponentName,
   getExt,
@@ -17,7 +17,7 @@ export default plugin({
     ctx.pages.forEach(page => {
       const demoComponents: DemoComponent[] = [];
 
-      visit(page.ast, 'code', (node: CodeNode) => {
+      visit(page.ast, 'code', node => {
         if (['preview-template', 'preview'].includes(node.meta || '')) {
           demoComponents.push({
             name: generateDemoComponentName(

--- a/packages/ember-cli/src/plugins/replace-internal-links-with-docfy-link.ts
+++ b/packages/ember-cli/src/plugins/replace-internal-links-with-docfy-link.ts
@@ -1,23 +1,14 @@
 import plugin from '@docfy/core/lib/plugin.js';
 import { visit } from 'unist-util-visit';
 import { PageContent } from '@docfy/core/lib/types.js';
-import { Node, Parent } from 'unist';
-import { u } from 'unist-builder';
+import { html } from './utils';
+import type { Root, RootContent } from 'mdast';
 
-interface LinkNode extends Node {
-  title: string | null;
-  url: string;
-  children: Node[];
-}
-
-function visitor(page: PageContent): void {
-  visit(page.ast, 'link', (visited, index, visitedParent) => {
-    const node = visited as unknown as LinkNode;
-    const parent = visitedParent as unknown as Parent | undefined;
-
+function visitor(page: PageContent<Root>): void {
+  visit(page.ast, 'link', (node, index, parent) => {
     if (node.url[0] === '/') {
       const data = node.data || (node.data = {});
-      const props = (data.hProperties || (data.hProperties = {})) as Record<string, unknown>;
+      const props = data.hProperties || (data.hProperties = {});
 
       const urlParts = node.url.split('#');
       const attributes = Object.keys(props)
@@ -26,18 +17,26 @@ function visitor(page: PageContent): void {
         })
         .join(' ');
 
-      const toInsert: Node[] = [
-        u(
-          'html',
+      const toInsert: RootContent[] = [
+        html(
           `<DocfyLink @to="${urlParts[0]}" ${
             urlParts[1] ? `@anchor="${urlParts[1]}"` : ''
           } ${attributes}>`
         ),
         ...node.children,
-        u('html', `</DocfyLink>`),
+        html(`</DocfyLink>`),
       ];
 
-      parent?.children.splice(index, 1, ...toInsert);
+      if (parent && typeof index === 'number') {
+        // `visit` types `parent` as the union of every mdast parent, whose
+        // `children` arrays hold different node types, so `splice` is not
+        // callable on the union. The raw `html` nodes also sit where mdast only
+        // allows phrasing content; `mdast-util-to-hast` passes them through
+        // untouched, which is what makes the surrounding tags work.
+        const children = (parent as unknown as { children: RootContent[] }).children;
+
+        children.splice(index, 1, ...toInsert);
+      }
     }
   });
 }

--- a/packages/ember-cli/src/plugins/types.ts
+++ b/packages/ember-cli/src/plugins/types.ts
@@ -1,21 +1,13 @@
-import { Node } from 'unist';
+import type { Code, Root } from 'mdast';
 
-interface Literal {
-  value: string;
-}
-
-export interface CodeNode extends Node, Literal {
-  type: 'code';
-  lang?: string;
-  meta?: string;
-}
+export type CodeNode = Code;
 
 export interface DemoComponent {
   name: DemoComponentName;
   chunks: DemoComponentChunk[];
   description?: {
     title?: string;
-    ast: Node;
+    ast: Root;
     editUrl?: string;
   };
 }
@@ -29,5 +21,5 @@ export interface DemoComponentChunk {
   type: string;
   code: string;
   ext: string;
-  snippet: Node;
+  snippet: Code;
 }

--- a/packages/ember-cli/src/plugins/utils.ts
+++ b/packages/ember-cli/src/plugins/utils.ts
@@ -1,6 +1,36 @@
-import { Node } from 'unist';
-import { u } from 'unist-builder';
+import { visit, EXIT } from 'unist-util-visit';
+import type { Heading, Html, Root, RootContent } from 'mdast';
 import { DemoComponent, DemoComponentName } from './types';
+
+/*
+ * Builds a raw `html` mdast node.
+ *
+ * This replaces `unist-builder`'s `u('html', value)`, which returned an untyped
+ * node. `html` is a real mdast node type, so the literal is all we need.
+ */
+export function html(value: string): Html {
+  return { type: 'html', value };
+}
+
+/*
+ * Finds the first heading in the tree matching a predicate.
+ *
+ * This replaces `unist-util-find`, which is unmaintained and returns a bare
+ * unist `Node` — losing `depth` and `data` and forcing a cast at every call
+ * site.
+ */
+export function findHeading(tree: Root, test: (node: Heading) => boolean): Heading | undefined {
+  let found: Heading | undefined;
+
+  visit(tree, 'heading', node => {
+    if (test(node)) {
+      found = node;
+      return EXIT;
+    }
+  });
+
+  return found;
+}
 
 /**
  * Creates all the Nodes necessary to render a Demo Component.
@@ -22,50 +52,48 @@ import { DemoComponent, DemoComponentName } from './types';
  * </DocfyDemo>
  * ```
  */
-export function createDemoNodes(component: DemoComponent): Node[] {
-  const nodes: Node[] = [u('html', `<DocfyDemo @id="${component.name.dashCase}" as |demo|>`)];
+export function createDemoNodes(component: DemoComponent): RootContent[] {
+  const nodes: RootContent[] = [html(`<DocfyDemo @id="${component.name.dashCase}" as |demo|>`)];
 
   if (component.description) {
     nodes.push(
-      u(
-        'html',
+      html(
         `<demo.Description
           ${component.description.title ? `@title="${component.description.title}" ` : ''}${
             component.description.editUrl ? `@editUrl="${component.description.editUrl}"` : ''
           }>`
       ),
-      component.description.ast,
-      u('html', '</demo.Description>')
+      // The demo's description is a whole `Root`. mdast has no node type for a
+      // nested tree, but `mdast-util-to-hast` has a `root` handler, so it is
+      // rendered inline where it sits.
+      component.description.ast as unknown as RootContent,
+      html('</demo.Description>')
     );
   }
 
   nodes.push(
-    u('html', '<demo.Example>'),
-    u('html', `<${component.name.pascalCase} />`),
-    u('html', '</demo.Example>')
+    html('<demo.Example>'),
+    html(`<${component.name.pascalCase} />`),
+    html('</demo.Example>')
   );
 
   if (component.chunks.length > 1) {
-    nodes.push(u('html', '<demo.Snippets as |Snippet|>'));
+    nodes.push(html('<demo.Snippets as |Snippet|>'));
     component.chunks.forEach(chunk => {
-      nodes.push(
-        u('html', `<Snippet @name="${chunk.type}">`),
-        chunk.snippet,
-        u('html', '</Snippet>')
-      );
+      nodes.push(html(`<Snippet @name="${chunk.type}">`), chunk.snippet, html('</Snippet>'));
     });
-    nodes.push(u('html', '</demo.Snippets>'));
+    nodes.push(html('</demo.Snippets>'));
   } else {
     component.chunks.forEach(chunk => {
       nodes.push(
-        u('html', `<demo.Snippet @name="${chunk.type}">`),
+        html(`<demo.Snippet @name="${chunk.type}">`),
         chunk.snippet,
-        u('html', '</demo.Snippet>')
+        html('</demo.Snippet>')
       );
     });
   }
 
-  nodes.push(u('html', '</DocfyDemo>'));
+  nodes.push(html('</DocfyDemo>'));
 
   return nodes;
 }
@@ -89,30 +117,30 @@ export function getExt(lang: string): string {
 /*
  * Delete a node from a list of nodes
  */
-export function deleteNode(nodes: unknown, nodeToDelete: Node | undefined): void {
+export function deleteNode(nodes: RootContent[], nodeToDelete: RootContent | undefined): void {
   if (!nodeToDelete) {
     return;
   }
 
-  if (Array.isArray(nodes)) {
-    const index = nodes.findIndex(item => item === nodeToDelete);
+  const index = nodes.findIndex(item => item === nodeToDelete);
 
-    if (index !== -1) {
-      nodes.splice(index, 1);
-    }
+  if (index !== -1) {
+    nodes.splice(index, 1);
   }
 }
 
 /*
  * Replace a node from a list of nodes
  */
-export function replaceNode(nodes: unknown, nodeToDelete: Node, ...newNodes: Node[]): void {
-  if (Array.isArray(nodes)) {
-    const index = nodes.findIndex(item => item === nodeToDelete);
+export function replaceNode(
+  nodes: RootContent[],
+  nodeToReplace: RootContent,
+  ...newNodes: RootContent[]
+): void {
+  const index = nodes.findIndex(item => item === nodeToReplace);
 
-    if (index !== -1) {
-      nodes.splice(index, 1, ...newNodes);
-    }
+  if (index !== -1) {
+    nodes.splice(index, 1, ...newNodes);
   }
 }
 

--- a/packages/ember-vite/package.json
+++ b/packages/ember-vite/package.json
@@ -46,8 +46,6 @@
     "fast-glob": "^3.2.0",
     "mdast-util-to-string": "^4.0.0",
     "remark-hbs": "^0.4.1",
-    "unist-builder": "^4.0.0",
-    "unist-util-find": "^3.0.0",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
@@ -57,7 +55,7 @@
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@types/node": "^24.0.14",
-    "@types/unist": "^2.0.0",
+    "@types/unist": "^3.0.0",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-n": "^17.18.0",

--- a/packages/ember-vite/src/docfy-plugins/demo-components.ts
+++ b/packages/ember-vite/src/docfy-plugins/demo-components.ts
@@ -1,6 +1,5 @@
 import plugin from '@docfy/core/lib/plugin.js';
 import { visit } from 'unist-util-visit';
-import { find as findNode } from 'unist-util-find';
 import { toString } from 'mdast-util-to-string';
 import path from 'path';
 import {
@@ -8,12 +7,13 @@ import {
   getExt,
   createDemoNodes,
   deleteNode,
+  findHeading,
   isDemoComponents,
 } from './utils.js';
 
 import type { Context, PageContent } from '@docfy/core/lib/types.js';
-import type { DemoComponent, DemoComponentChunk, CodeNode, PluginData } from '../types.js';
-import type { Node, Parent } from 'unist';
+import type { DemoComponent, DemoComponentChunk, PluginData } from '../types.js';
+import type { Heading, Paragraph, Root, RootContent } from 'mdast';
 
 /*
  * Create the heading for the examples section of the page.
@@ -23,85 +23,97 @@ import type { Node, Parent } from 'unist';
  *
  * This is necessary for apps using remark-autolink-headings, for example.
  */
-function createHeading(ctx: Context): Node {
-  const heading = (ctx.remark.runSync(ctx.remark.parse('## Examples')).children as Node[])[0];
+function createHeading(ctx: Context<Root>): Heading {
+  // `## Examples` always parses to a single heading. Remark plugins in the
+  // stack can annotate it, but none of them replace it with another node type.
+  const heading = ctx.remark.runSync(ctx.remark.parse('## Examples')).children[0] as Heading;
   heading.depth = 2;
   return heading;
 }
 
-const isTextMarker = (node: Parent): boolean =>
-  node.type === 'paragraph' && node.children.length === 1 && node.children[0].type === 'text';
+/*
+ * Returns the text of a paragraph made up of a single text node, which is the
+ * shape every demo marker has.
+ */
+function markerText(node: Paragraph): string {
+  const child = node.children[0];
+  return node.children.length === 1 && child.type === 'text' ? child.value : '';
+}
 
 const demoMarkerRegex = /^\[\[demo:(.+?)\]\]$/;
-const demoMarker = (node: Parent): boolean =>
-  isTextMarker(node) && demoMarkerRegex.test(node.children[0].value as string);
+const demoMarker = (node: Paragraph): boolean => demoMarkerRegex.test(markerText(node));
 
 const demosAllMarkerRegex = /^\[\[demos-all\]\]$/;
-const demosAllMarker = (node: Parent): boolean =>
-  isTextMarker(node) && demosAllMarkerRegex.test(node.children[0].value as string);
+const demosAllMarker = (node: Paragraph): boolean => demosAllMarkerRegex.test(markerText(node));
+
+/*
+ * Replaces a demo marker paragraph with the given demo nodes.
+ *
+ * The paragraph is retyped to `div` so that `mdast-util-to-hast` falls back to
+ * its unknown-node handler and emits a plain `<div>`: a `<p>` cannot legally
+ * wrap the block-level markup being spliced in. Neither retyping a node nor
+ * putting block content inside a paragraph is expressible in mdast, so the
+ * marker is widened here.
+ */
+function replaceMarkerWithDemoNodes(marker: Paragraph, nodes: RootContent[]): void {
+  const container = marker as unknown as { type: string; children: RootContent[] };
+
+  container.type = 'div';
+  container.children.splice(0, 1, ...nodes);
+}
 
 /*
  * Insert Demo nodes into the page.
  */
-function insertDemoNodesIntoPage(page: PageContent, toInsert: Node[]): void {
-  if (Array.isArray(page.ast.children)) {
-    const secondHeading = findNode(
-      page.ast,
-      (node: Node) => node.type === 'heading' && node.depth !== 1
-    );
+function insertDemoNodesIntoPage(page: PageContent<Root>, toInsert: RootContent[]): void {
+  const secondHeading = findHeading(page.ast, node => node.depth !== 1);
 
-    if (secondHeading) {
-      const index = page.ast.children.findIndex(el => el === secondHeading);
-      page.ast.children.splice(index, 0, ...toInsert);
-    } else {
-      page.ast.children.push(...toInsert);
-    }
+  if (secondHeading) {
+    const index = page.ast.children.findIndex(el => el === secondHeading);
+    page.ast.children.splice(index, 0, ...toInsert);
+  } else {
+    page.ast.children.push(...toInsert);
   }
 }
 
-function replaceDemoMarkers(page: PageContent, demos: DemoComponent[]): void {
-  if (Array.isArray(page.ast.children)) {
-    const markers: Parent[] = [];
-    const allMarkers: Parent[] = [];
+function replaceDemoMarkers(page: PageContent<Root>, demos: DemoComponent[]): void {
+  const markers: Paragraph[] = [];
+  const allMarkers: Paragraph[] = [];
 
-    visit(page.ast, 'paragraph', (node: Parent) => {
-      if (demoMarker(node)) markers.push(node);
-      if (demosAllMarker(node)) allMarkers.push(node);
-    });
+  visit(page.ast, 'paragraph', node => {
+    if (demoMarker(node)) markers.push(node);
+    if (demosAllMarker(node)) allMarkers.push(node);
+  });
 
-    markers.forEach(marker => {
-      const child = marker.children[0];
-      const matches = (child.value as string).match(demoMarkerRegex);
-      if (!matches) return;
+  markers.forEach(marker => {
+    const matches = markerText(marker).match(demoMarkerRegex);
+    if (!matches) return;
 
-      // TODO: This is an inner loop and can cause perf issues if someone
-      // out there has many demos on a single page. It would be better to
-      // create a demo component hash that can be looked up by demo name.
-      const demoName = matches[1];
-      const demo = demos.find(d => d.name.dashCase.endsWith(demoName));
+    // TODO: This is an inner loop and can cause perf issues if someone
+    // out there has many demos on a single page. It would be better to
+    // create a demo component hash that can be looked up by demo name.
+    const demoName = matches[1];
+    const demo = demos.find(d => d.name.dashCase.endsWith(demoName));
 
-      if (!demo) {
-        console.warn(
-          `Found demo marker "${demoName}" with no matching demo component in ${page.source}`
-        );
-        return;
-      }
+    if (!demo) {
+      console.warn(
+        `Found demo marker "${demoName}" with no matching demo component in ${page.source}`
+      );
+      return;
+    }
 
-      marker.type = 'div';
-      marker.children.splice(0, 1, ...createDemoNodes(demo));
-    });
+    replaceMarkerWithDemoNodes(marker, createDemoNodes(demo));
+  });
 
-    allMarkers.forEach(marker => {
-      const demoNodes = demos.map(component => createDemoNodes(component)).flat();
+  allMarkers.forEach(marker => {
+    const demoNodes = demos.map(component => createDemoNodes(component)).flat();
 
-      marker.type = 'div';
-      marker.children.splice(0, 1, ...demoNodes);
-    });
-  }
+    replaceMarkerWithDemoNodes(marker, demoNodes);
+  });
 }
 
 export default plugin({
-  runWithMdast(ctx: Context): void {
+  runWithMdast(ctx): void {
     const seenNames: Set<string> = new Set();
 
     ctx.pages.forEach(page => {
@@ -111,7 +123,7 @@ export default plugin({
         page.demos.forEach(demo => {
           const chunks: DemoComponentChunk[] = [];
 
-          visit(demo.ast, 'code', (node: CodeNode) => {
+          visit(demo.ast, 'code', node => {
             if (['component', 'template', 'styles'].includes(node.meta || '')) {
               chunks.push({
                 snippet: node,
@@ -131,10 +143,7 @@ export default plugin({
             seenNames
           );
 
-          const demoTitle = findNode(
-            demo.ast,
-            (node: Node) => node.type === 'heading' && node.depth === 1
-          );
+          const demoTitle = findHeading(demo.ast, node => node.depth === 1);
 
           if (demoTitle) {
             demoTitle.depth = 3;
@@ -168,7 +177,7 @@ export default plugin({
         } else {
           // Automatic demo insertion creates an Example block after
           // the first heading.
-          const toInsert: Node[] = [createHeading(ctx)];
+          const toInsert: RootContent[] = [createHeading(ctx)];
           demoComponents.forEach(component => {
             toInsert.push(...createDemoNodes(component));
           });

--- a/packages/ember-vite/src/docfy-plugins/docfy-link-conversion.ts
+++ b/packages/ember-vite/src/docfy-plugins/docfy-link-conversion.ts
@@ -1,27 +1,21 @@
 import plugin from '@docfy/core/lib/plugin.js';
 import { visit } from 'unist-util-visit';
-import { u } from 'unist-builder';
-import type { Context, PageContent } from '@docfy/core/lib/types.js';
-import type { Node, Parent } from 'unist';
+import { html } from './utils.js';
+import type { PageContent } from '@docfy/core/lib/types.js';
+import type { Root, RootContent } from 'mdast';
 import type { PluginData } from '../types.js';
 import { getComponentImport } from '../import-map.js';
 
-interface LinkNode extends Node {
-  title: string | null;
-  url: string;
-  children: Node[];
-}
-
-function processPageForInternalLinks(page: PageContent): boolean {
+function processPageForInternalLinks(page: PageContent<Root>): boolean {
   let hasInternalLinks = false;
 
-  visit(page.ast, 'link', (node: LinkNode, index: number, parent: Parent | undefined) => {
+  visit(page.ast, 'link', (node, index, parent) => {
     // Only process internal links that start with '/'
     if (node.url && node.url[0] === '/') {
       hasInternalLinks = true;
 
       const data = node.data || (node.data = {});
-      const props = (data.hProperties || (data.hProperties = {})) as Record<string, unknown>;
+      const props = data.hProperties || (data.hProperties = {});
 
       const urlParts = node.url.split('#');
       const attributes = Object.keys(props)
@@ -30,19 +24,25 @@ function processPageForInternalLinks(page: PageContent): boolean {
         })
         .join(' ');
 
-      const toInsert: Node[] = [
-        u(
-          'html',
+      const toInsert: RootContent[] = [
+        html(
           `<DocfyLink @to="${urlParts[0]}" ${
             urlParts[1] ? `@anchor="${urlParts[1]}"` : ''
           } ${attributes}>`
         ),
         ...node.children,
-        u('html', `</DocfyLink>`),
+        html(`</DocfyLink>`),
       ];
 
-      if (parent && parent.children) {
-        parent.children.splice(index, 1, ...toInsert);
+      if (parent && typeof index === 'number') {
+        // `visit` types `parent` as the union of every mdast parent, whose
+        // `children` arrays hold different node types, so `splice` is not
+        // callable on the union. The raw `html` nodes also sit where mdast only
+        // allows phrasing content; `mdast-util-to-hast` passes them through
+        // untouched, which is what makes the surrounding tags work.
+        const children = (parent as unknown as { children: RootContent[] }).children;
+
+        children.splice(index, 1, ...toInsert);
       }
     }
   });
@@ -60,7 +60,7 @@ function processPageForInternalLinks(page: PageContent): boolean {
  * [API Reference](/docs/api#configuration) -> <DocfyLink @to="/docs/api" @anchor="configuration">API Reference</DocfyLink>
  */
 export default plugin({
-  runWithMdast(ctx: Context): void {
+  runWithMdast(ctx): void {
     ctx.pages.forEach(page => {
       // Process page content and check for internal links in one pass
       const pageHasInternalLinks = processPageForInternalLinks(page);

--- a/packages/ember-vite/src/docfy-plugins/escape-curlies-in-code.ts
+++ b/packages/ember-vite/src/docfy-plugins/escape-curlies-in-code.ts
@@ -1,7 +1,6 @@
 import plugin from '@docfy/core/lib/plugin.js';
 import { visit } from 'unist-util-visit';
-import type { Node } from 'unist';
-import type { Element, Text } from 'hast';
+import type { Root } from 'hast';
 import type { PageContent } from '@docfy/core/lib/types.js';
 
 /**
@@ -15,13 +14,13 @@ import type { PageContent } from '@docfy/core/lib/types.js';
  * bare `{{` into the output. Running at the hast stage (`runWithHast`, which
  * Docfy invokes after all rehype plugins) escapes the final text instead.
  */
-function escapeCurliesInCode(ast: Node): void {
-  visit(ast, 'element', (node: Element) => {
+function escapeCurliesInCode(ast: Root): void {
+  visit(ast, 'element', node => {
     if (node.tagName !== 'code') {
       return;
     }
 
-    visit(node, 'text', (textNode: Text) => {
+    visit(node, 'text', textNode => {
       textNode.value = textNode.value.replace(/\{\{/g, '\\{{');
     });
 
@@ -32,7 +31,7 @@ function escapeCurliesInCode(ast: Node): void {
 
 export default plugin({
   runWithHast(ctx): void {
-    const escape = (page: PageContent): void => {
+    const escape = (page: PageContent<Root>): void => {
       escapeCurliesInCode(page.ast);
       page.demos?.forEach(escape);
     };

--- a/packages/ember-vite/src/docfy-plugins/preview-templates.ts
+++ b/packages/ember-vite/src/docfy-plugins/preview-templates.ts
@@ -9,7 +9,7 @@ import {
 } from './utils.js';
 import path from 'path';
 
-import type { DemoComponent, CodeNode } from '../types.js';
+import type { DemoComponent } from '../types.js';
 
 export default plugin({
   runWithMdast(ctx): void {
@@ -18,7 +18,7 @@ export default plugin({
     ctx.pages.forEach(page => {
       const demoComponents: DemoComponent[] = [];
 
-      visit(page.ast, 'code', (node: CodeNode) => {
+      visit(page.ast, 'code', node => {
         if (['preview-template', 'preview'].includes(node.meta || '')) {
           demoComponents.push({
             name: generateDemoComponentName(

--- a/packages/ember-vite/src/docfy-plugins/utils.ts
+++ b/packages/ember-vite/src/docfy-plugins/utils.ts
@@ -1,5 +1,5 @@
-import { u } from 'unist-builder';
-import { Node } from 'unist';
+import { visit, EXIT } from 'unist-util-visit';
+import type { Heading, Html, Root, RootContent } from 'mdast';
 import type { DemoComponent, DemoComponentName } from '../types.js';
 
 // Map language names to file extensions (same as original ember implementation)
@@ -31,77 +31,106 @@ export function isDemoComponents(components: unknown): components is DemoCompone
   return false;
 }
 
-// Utility functions (same as original ember implementation)
-export function replaceNode(nodes: unknown, nodeToDelete: any, ...newNodes: any[]): void {
-  if (Array.isArray(nodes)) {
-    const index = nodes.findIndex(item => item === nodeToDelete);
-    if (index !== -1) {
-      nodes.splice(index, 1, ...newNodes);
+/*
+ * Builds a raw `html` mdast node.
+ *
+ * This replaces `unist-builder`'s `u('html', value)`, which returned an untyped
+ * node. `html` is a real mdast node type, so the literal is all we need.
+ */
+export function html(value: string): Html {
+  return { type: 'html', value };
+}
+
+/*
+ * Finds the first heading in the tree matching a predicate.
+ *
+ * This replaces `unist-util-find`, which is unmaintained and returns a bare
+ * unist `Node` — losing `depth` and `data` and forcing a cast at every call
+ * site.
+ */
+export function findHeading(tree: Root, test: (node: Heading) => boolean): Heading | undefined {
+  let found: Heading | undefined;
+
+  visit(tree, 'heading', node => {
+    if (test(node)) {
+      found = node;
+      return EXIT;
     }
+  });
+
+  return found;
+}
+
+// Utility functions (same as original ember implementation)
+export function replaceNode(
+  nodes: RootContent[],
+  nodeToReplace: RootContent,
+  ...newNodes: RootContent[]
+): void {
+  const index = nodes.findIndex(item => item === nodeToReplace);
+
+  if (index !== -1) {
+    nodes.splice(index, 1, ...newNodes);
   }
 }
 
-export function createDemoNodes(component: DemoComponent): Node[] {
-  const nodes: Node[] = [u('html', `<DocfyDemo @id="${component.name.dashCase}" as |demo|>`)];
+export function createDemoNodes(component: DemoComponent): RootContent[] {
+  const nodes: RootContent[] = [html(`<DocfyDemo @id="${component.name.dashCase}" as |demo|>`)];
 
   if (component.description) {
     nodes.push(
-      u(
-        'html',
+      html(
         `<demo.Description
           ${component.description.title ? `@title="${component.description.title}" ` : ''}${
             component.description.editUrl ? `@editUrl="${component.description.editUrl}"` : ''
           }>`
       ),
-      component.description.ast,
-      u('html', '</demo.Description>')
+      // The demo's description is a whole `Root`. mdast has no node type for a
+      // nested tree, but `mdast-util-to-hast` has a `root` handler, so it is
+      // rendered inline where it sits.
+      component.description.ast as unknown as RootContent,
+      html('</demo.Description>')
     );
   }
 
   nodes.push(
-    u('html', '<demo.Example>'),
-    u('html', `<${component.name.pascalCase} />`),
-    u('html', '</demo.Example>')
+    html('<demo.Example>'),
+    html(`<${component.name.pascalCase} />`),
+    html('</demo.Example>')
   );
 
   if (component.chunks.length > 1) {
-    nodes.push(u('html', '<demo.Snippets as |Snippet|>'));
+    nodes.push(html('<demo.Snippets as |Snippet|>'));
     component.chunks.forEach(chunk => {
-      nodes.push(
-        u('html', `<Snippet @name="${chunk.type}">`),
-        chunk.snippet,
-        u('html', '</Snippet>')
-      );
+      nodes.push(html(`<Snippet @name="${chunk.type}">`), chunk.snippet, html('</Snippet>'));
     });
-    nodes.push(u('html', '</demo.Snippets>'));
+    nodes.push(html('</demo.Snippets>'));
   } else {
     component.chunks.forEach(chunk => {
       nodes.push(
-        u('html', `<demo.Snippet @name="${chunk.type}">`),
+        html(`<demo.Snippet @name="${chunk.type}">`),
         chunk.snippet,
-        u('html', '</demo.Snippet>')
+        html('</demo.Snippet>')
       );
     });
   }
 
-  nodes.push(u('html', '</DocfyDemo>'));
+  nodes.push(html('</DocfyDemo>'));
 
   return nodes;
 }
 /*
  * Delete a node from a list of nodes
  */
-export function deleteNode(nodes: unknown, nodeToDelete: Node | undefined): void {
+export function deleteNode(nodes: RootContent[], nodeToDelete: RootContent | undefined): void {
   if (!nodeToDelete) {
     return;
   }
 
-  if (Array.isArray(nodes)) {
-    const index = nodes.findIndex(item => item === nodeToDelete);
+  const index = nodes.findIndex(item => item === nodeToDelete);
 
-    if (index !== -1) {
-      nodes.splice(index, 1);
-    }
+  if (index !== -1) {
+    nodes.splice(index, 1);
   }
 }
 

--- a/packages/ember-vite/src/types.ts
+++ b/packages/ember-vite/src/types.ts
@@ -1,13 +1,7 @@
-import type { Node } from 'unist';
+import type { Code, Root } from 'mdast';
 
-interface Literal {
-  value: string;
-}
-export interface CodeNode extends Node, Literal {
-  type: 'code';
-  lang?: string;
-  meta?: string;
-}
+export type CodeNode = Code;
+
 export interface ImportStatement {
   name: string;
   path: string;
@@ -25,7 +19,7 @@ export interface DemoComponentChunk {
   type: string;
   code: string;
   ext: string;
-  snippet: Node; // AST node reference
+  snippet: Code; // AST node reference
 }
 
 export interface DemoComponent {
@@ -33,7 +27,7 @@ export interface DemoComponent {
   chunks: DemoComponentChunk[];
   description?: {
     title?: string;
-    ast: Node; // AST node reference
+    ast: Root; // AST node reference
     editUrl?: string;
   };
 }

--- a/packages/plugin-with-prose/package.json
+++ b/packages/plugin-with-prose/package.json
@@ -25,8 +25,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^22.10.5",
-    "@types/unist": "^2.0.0",
     "eslint": "^9.32.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-n": "^17.18.0",

--- a/packages/plugin-with-prose/src/index.ts
+++ b/packages/plugin-with-prose/src/index.ts
@@ -1,15 +1,10 @@
 import plugin from '@docfy/core/lib/plugin.js';
-import { PageContent } from '@docfy/core/lib/types';
-import type { Node, Parent } from 'unist';
-
-interface NodeWithMeta extends Node {
-  meta?: string;
-}
+import type { Html, Root, RootContent } from 'mdast';
 
 // This plugin was inpired by TailwindCSS's code:
 // https://github.com/tailwindlabs/tailwindcss.com/blob/1234b4faded6c7a06b734c49c61257137b4acc9b/remark/withProse.js
 
-function shouldUnproseNode(node: NodeWithMeta): boolean {
+function shouldUnproseNode(node: RootContent): boolean {
   return Boolean(
     node.type === 'code' &&
     node.meta &&
@@ -17,16 +12,16 @@ function shouldUnproseNode(node: NodeWithMeta): boolean {
   );
 }
 
-function withProse(tree: Parent, className = 'prose', notClassName = 'not-prose'): void {
-  const openProse = () => ({
+function withProse(tree: Root, className = 'prose', notClassName = 'not-prose'): void {
+  const openProse = (): Html => ({
     type: 'html',
     value: `<div class="${className}">`,
   });
-  const openNotProse = () => ({
+  const openNotProse = (): Html => ({
     type: 'html',
     value: `<div class="${notClassName}">`,
   });
-  const close = () => ({ type: 'html', value: '</div>' });
+  const close = (): Html => ({ type: 'html', value: '</div>' });
 
   tree.children = [
     openProse(),
@@ -49,17 +44,9 @@ interface WithProseOptions {
   className?: string;
 }
 
-interface Page {
-  ast: Parent;
-  demos?: Page[];
-}
-
 const DocfyPluginWithProse = plugin.withOptions<WithProseOptions | undefined>({
   runWithMdast(ctx, options) {
-    ctx.pages.forEach((pageContent: PageContent) => {
-      // PageContent may not have children, which is required for withProse
-      // TODO: pageContent may need to be a union type
-      const page = pageContent as unknown as Page;
+    ctx.pages.forEach(page => {
       withProse(page.ast, options?.className);
 
       page.demos?.forEach(demo => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/unist': 2.0.3
-
 importers:
 
   .:
@@ -94,8 +91,8 @@ importers:
         specifier: ^24.0.14
         version: 24.13.3
       '@types/unist':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: ^3.0.0
+        version: 3.0.3
       eslint:
         specifier: ^9.32.0
         version: 9.39.5(jiti@2.7.0)
@@ -291,12 +288,6 @@ importers:
       remark-hbs:
         specifier: ^0.4.1
         version: 0.4.1
-      unist-builder:
-        specifier: ^4.0.0
-        version: 4.0.0
-      unist-util-find:
-        specifier: ^3.0.0
-        version: 3.0.0
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -332,8 +323,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4
       '@types/unist':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: ^3.0.0
+        version: 3.0.3
       autoprefixer:
         specifier: ^10.4.21
         version: 10.5.4(postcss@8.5.25)
@@ -478,12 +469,6 @@ importers:
       remark-hbs:
         specifier: ^0.4.1
         version: 0.4.1
-      unist-builder:
-        specifier: ^4.0.0
-        version: 4.0.0
-      unist-util-find:
-        specifier: ^3.0.0
-        version: 3.0.0
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -510,8 +495,8 @@ importers:
         specifier: ^24.0.14
         version: 24.13.3
       '@types/unist':
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: ^3.0.0
+        version: 3.0.3
       eslint:
         specifier: ^9.32.0
         version: 9.39.5(jiti@2.7.0)
@@ -549,12 +534,12 @@ importers:
       '@eslint/js':
         specifier: ^9.32.0
         version: 9.39.5
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.10.5
         version: 22.20.1
-      '@types/unist':
-        specifier: 2.0.3
-        version: 2.0.3
       eslint:
         specifier: ^9.32.0
         version: 9.39.5(jiti@2.7.0)
@@ -3045,6 +3030,9 @@ packages:
 
   '@types/unist@2.0.3':
     resolution: {integrity: sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -6984,9 +6972,6 @@ packages:
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
 
-  lodash.iteratee@4.7.0:
-    resolution: {integrity: sha512-yv3cSQZmfpbIKo4Yo45B1taEvxjNvcpF1CEOc0Y6dEyvhPIfEJE3twDwPgWTPQubcSgXyBwBKG6wpQvWMDOf6Q==}
-
   lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
 
@@ -9810,14 +9795,8 @@ packages:
   unist-builder@2.0.3:
     resolution: {integrity: sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==}
 
-  unist-builder@4.0.0:
-    resolution: {integrity: sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==}
-
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
-
-  unist-util-find@3.0.0:
-    resolution: {integrity: sha512-T7ZqS7immLjYyC4FCp2hDo3ksZ1v+qcbb+e5+iWxc2jONgHOLXPCpms1L8VV4hVxCXgWTxmBHDztuEZFVwC+Gg==}
 
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
@@ -12702,6 +12681,8 @@ snapshots:
   '@types/symlink-or-copy@1.2.2': {}
 
   '@types/unist@2.0.3': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -17367,7 +17348,7 @@ snapshots:
   hast-util-from-parse5@8.0.3:
     dependencies:
       '@types/hast': 3.0.5
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       devlop: 1.1.0
       hastscript: 9.0.1
       property-information: 7.2.0
@@ -17392,7 +17373,7 @@ snapshots:
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.5
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
       hast-util-whitespace: 3.0.0
@@ -17408,7 +17389,7 @@ snapshots:
   hast-util-to-text@4.0.2:
     dependencies:
       '@types/hast': 3.0.5
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       hast-util-is-element: 3.0.0
       unist-util-find-after: 5.0.0
 
@@ -18436,8 +18417,6 @@ snapshots:
 
   lodash.ismatch@4.4.0: {}
 
-  lodash.iteratee@4.7.0: {}
-
   lodash.kebabcase@4.1.1: {}
 
   lodash.memoize@4.1.2: {}
@@ -18618,7 +18597,7 @@ snapshots:
   mdast-util-from-markdown@2.0.3:
     dependencies:
       '@types/mdast': 4.0.4
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
@@ -18732,7 +18711,7 @@ snapshots:
   mdast-util-to-markdown@2.1.2:
     dependencies:
       '@types/mdast': 4.0.4
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       longest-streak: 3.1.0
       mdast-util-phrasing: 4.1.0
       mdast-util-to-string: 4.0.0
@@ -22155,7 +22134,7 @@ snapshots:
 
   unified@11.0.5:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       bail: 2.0.2
       devlop: 1.1.0
       extend: 3.0.2
@@ -22186,20 +22165,10 @@ snapshots:
 
   unist-builder@2.0.3: {}
 
-  unist-builder@4.0.0:
-    dependencies:
-      '@types/unist': 2.0.3
-
   unist-util-find-after@5.0.0:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
-
-  unist-util-find@3.0.0:
-    dependencies:
-      '@types/unist': 2.0.3
-      lodash.iteratee: 4.7.0
-      unist-util-visit: 5.1.0
 
   unist-util-is@4.1.0: {}
 
@@ -22209,15 +22178,15 @@ snapshots:
 
   unist-util-is@6.0.1:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
 
   unist-util-position@5.0.0:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
 
   unist-util-remove-position@5.0.0:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
 
   unist-util-stringify-position@2.0.3:
@@ -22226,7 +22195,7 @@ snapshots:
 
   unist-util-stringify-position@4.0.0:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
 
   unist-util-visit-parents@3.1.1:
     dependencies:
@@ -22240,7 +22209,7 @@ snapshots:
 
   unist-util-visit-parents@6.0.2:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
 
   unist-util-visit@2.0.3:
@@ -22257,7 +22226,7 @@ snapshots:
 
   unist-util-visit@5.1.0:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
@@ -22322,7 +22291,7 @@ snapshots:
 
   vfile-location@5.0.3:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       vfile: 6.0.3
 
   vfile-message@2.0.4:
@@ -22332,7 +22301,7 @@ snapshots:
 
   vfile-message@4.0.3:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
   vfile@4.2.1:
@@ -22344,7 +22313,7 @@ snapshots:
 
   vfile@6.0.3:
     dependencies:
-      '@types/unist': 2.0.3
+      '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
   vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.49.0)(yaml@2.9.0):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,19 +3,6 @@ packages:
   - 'test-app-vite'
   - 'test-app-classic'
 
-# Replaces yarn's `resolutions`. pnpm 11 reads overrides from this file, not
-# from the root package.json.
-#
-# The unist v2 types are still pinned because the Ember integrations' Docfy
-# plugins are written against v2's loose `Node` (which carried an index
-# signature, so `node.value` / `node.depth` type-check on a bare node). They
-# also intentionally build synthetic nodes and reassign `node.type`, which
-# strict mdast `Root`/`RootContent` types cannot express. Runtime is unaffected
-# — this is types-only. Migrating those plugins to real mdast types (and then
-# dropping this pin) is tracked separately.
-overrides:
-  '@types/unist': 2.0.3
-
 # pnpm blocks dependency build scripts unless explicitly allowed here.
 # esbuild's postinstall installs its platform binary, without which vite cannot
 # build; nx is lerna's task engine. core-js 2.x's postinstall only prints a


### PR DESCRIPTION
Removes the `@types/unist: 2.0.3` override that #213 deliberately left in place. This was the one wart that PR documented rather than fixed: Docfy runs on unified 11 / mdast v4 / hast v3 at runtime while the entire workspace type-checked against unist **v2**. It only worked because v2's `Node` carried an index signature, so loose accesses like `node.value` and `node.depth` type-checked on a bare node.

## Design: generic over the tree, not a union

`PageContent.ast` holds an mdast tree before Docfy's mdast→hast transform and a hast tree after it. Rather than typing it as `MdastRoot | HastRoot`, `PageContent` and `Context` are now generic over the tree, and each plugin hook declares the tree it actually receives:

```ts
runBefore?:    PluginHandler<T, MdastRoot>;
runWithMdast?: PluginHandler<T, MdastRoot>;
runWithHast?:  PluginHandler<T, HastRoot>;
runAfter?:     PluginHandler<T, HastRoot>;
```

Inside a handler, `page.ast` is a real `mdast.Root` or `hast.Root`, so `unist-util-visit` infers precise node types with no narrowing. Both types default to `MdastRoot | HastRoot`, so unannotated code keeps compiling. `DocfyResult.content` is now `PageContent<HastRoot>[]`, which is what it always actually was.

## What this deletes

Every hand-rolled `LinkNode`, `DefinitionNode`, `LinkReferenceNode`, `ImageNode`, `ImageReferenceNode`, `HeadingNode`, `NodeWithMeta`, and the local `Resource`/`Association`/`Literal` shims. They disagreed with mdast on nullability — `title?: string` where mdast says `string | null | undefined` — which is precisely why they existed. `CodeNode` survives as `type CodeNode = Code` to keep the public export. `data.id` / `data.docfyDelete` are now registered once by augmenting mdast's `HeadingData` instead of being re-declared per plugin.

Both dead dependencies are inlined: `unist-builder` became a three-line `html()` returning a real mdast `Html` node (`html` *is* an mdast type, so the synthetic-untyped-node problem disappears), and `unist-util-find` became a typed `findHeading()` over `unist-util-visit` + `EXIT`, removing the `.depth`/`.data` mutation casts at four call sites.

## Three casts remain, each commented

1. `marker.type = 'div'` — retyping a `Paragraph` and putting block content in it. Isolated into one helper per package so the cast appears once instead of twice.
2. Splicing into `parent.children` where `visit` widens `parent` to the union of all mdast parents, making `children[]` element types incompatible.
3. `component.description.ast as unknown as RootContent` — nesting a whole `Root` inside another tree's children, which `mdast-util-to-hast`'s `root` handler renders inline.

These are places the code intentionally plays loose with node types, which is legitimate remark practice; they are not expressible in strict mdast.

## Verification

`pnpm -r run compile` clean across all 6 packages. `@docfy/ember-vite` 60/60, `@docfy/plugin-with-prose` 2/2, `@docfy/core` at its documented baseline. Both test apps build; `test-app-vite` emits real Docfy routes and 31 `hljs-*` classes.

The important check is **no rendered output change**. The built bundle is byte-identical between baseline and this change (same sha1, and Vite's content-hashed filename is unchanged). I verified this a second, independent way: built in this worktree and diffed the generated `.gjs` templates against main's committed ones — every changed line pairs up exactly once the worktree directory name is normalised away, i.e. 10 insertions and 10 deletions that are all the same substitution. A green build alone would not have told us this.

## Breaking change note

Anyone who explicitly annotated a hook as `runWithMdast(ctx: Context)` will find `ctx.pages[i].ast` widened to the union and should drop the annotation to get the precise type. This came up twice inside `@docfy/ember-vite` and is fixed there. Worth a line in the release notes.

Depends on nothing; stacks cleanly with #214, #215 and #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
