### PR TITLE
fix: resolve the checkout root correctly inside a git worktree

### DIFF
--- a/packages/core/src/-private/repo-info.ts
+++ b/packages/core/src/-private/repo-info.ts
@@ -1,6 +1,40 @@
+import fs from 'fs';
 import path from 'path';
 import getRepoInfo from 'git-repo-info';
 import GitHost from 'hosted-git-info';
+
+/**
+ * Resolves the top level of the checkout that `target` lives in.
+ *
+ * `git-repo-info` documents that its `root` points at the original copy rather
+ * than the worktree when called from inside a linked worktree. Using it
+ * directly makes the relative path below include the worktree's own location,
+ * producing edit URLs for paths that do not exist on the remote.
+ *
+ * A worktree's metadata directory holds a `gitdir` file pointing at that
+ * worktree's `.git` file, and its parent is the top level we want. Outside a
+ * worktree `worktreeGitDir` and `commonGitDir` are the same, so there is
+ * nothing to correct.
+ */
+function getCheckoutRoot(target: string): string {
+  const { root, commonGitDir, worktreeGitDir } = getRepoInfo(target);
+
+  if (!worktreeGitDir || worktreeGitDir === commonGitDir) {
+    return root;
+  }
+
+  try {
+    const gitdir = fs.readFileSync(path.join(worktreeGitDir, 'gitdir'), 'utf8').trim();
+
+    if (gitdir) {
+      return path.dirname(gitdir);
+    }
+  } catch {
+    // No readable `gitdir` pointer, so fall back to the reported root.
+  }
+
+  return root;
+}
 
 // A whitelist, not a fallback: `getTreePath` only knows two URL shapes, Bitbucket's
 // and the `/edit/` form GitHub and GitLab accept. Every other host hosted-git-info can
@@ -30,7 +64,7 @@ export function getRepoEditUrl(root: string, repoURL: string, branch = 'master')
   let result: string | null = null;
 
   try {
-    const gitRoot = getRepoInfo(root).root;
+    const gitRoot = getCheckoutRoot(root);
     const repo = GitHost.fromUrl(repoURL);
     const relative = path.relative(gitRoot, root);
     const tree = getTreePath(repo, branch, relative);

--- a/packages/core/tests/repo-info-worktree.test.ts
+++ b/packages/core/tests/repo-info-worktree.test.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { getRepoEditUrl } from '../src/-private/repo-info.js';
+
+/**
+ * `git-repo-info` reports the *original* checkout's root when called from
+ * inside a linked worktree, which used to leak the worktree's own location into
+ * every edit URL. CI runs in a normal checkout, so without this test that
+ * regression would be invisible there.
+ */
+describe('getRepoEditUrl in a git worktree', () => {
+  // realpath matters: on macOS os.tmpdir() is a symlink and git records the
+  // resolved path, so comparing against the unresolved one would break.
+  const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'docfy-worktree-')));
+  const mainCheckout = path.join(tmp, 'main');
+  const worktree = path.join(tmp, 'linked');
+  const expected = 'https://github.com/user/repo/edit/main/docs/{filepath}';
+
+  beforeAll(() => {
+    const git = (...args: string[]): void => {
+      execFileSync('git', args, { cwd: mainCheckout, stdio: 'pipe' });
+    };
+
+    fs.mkdirSync(path.join(mainCheckout, 'docs'), { recursive: true });
+    git('init', '-b', 'main');
+    git('config', 'user.email', 'test@example.com');
+    git('config', 'user.name', 'Docfy Test');
+    fs.writeFileSync(path.join(mainCheckout, 'docs', 'index.md'), '# Hello\n');
+    git('add', '.');
+    git('commit', '-m', 'init');
+    git('worktree', 'add', worktree, '-b', 'feature');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  test('the edit url does not include the worktree location', () => {
+    expect(
+      getRepoEditUrl(path.join(worktree, 'docs'), 'https://github.com/user/repo', 'main')
+    ).toBe(expected);
+  });
+
+  test('the same source path resolves identically in the main checkout', () => {
+    expect(
+      getRepoEditUrl(path.join(mainCheckout, 'docs'), 'https://github.com/user/repo', 'main')
+    ).toBe(expected);
+  });
+});


### PR DESCRIPTION
Edit URLs are wrong for anyone running Docfy from a linked git worktree.

`getRepoEditUrl` computes `path.relative(getRepoInfo(root).root, root)`. git-repo-info's own typings document the trap:

> `root`: The root directory for the Git repo or submodule. **If in a worktree, this is the directory containing the original copy, not the worktree.**

So the relative path picks up the worktree's location and the URL points at a path that doesn't exist on the remote:

```
git-repo-info .root          : /Users/me/code/docfy            ← main checkout
git rev-parse --show-toplevel: /Users/me/code/docfy/.wt/branch ← actual worktree
→ relative = .wt/branch/docs   instead of   docs
```

## This already caused damage

Four committed `.gjs` templates shipped with `.claude/worktrees/<branch>/` baked into their `@editUrl` values — every "Edit this page" link on those demo pages 404'd until #214 fixed them by hand.

It is also the real reason `repo-info.test.ts` and `generating-edit-url.test.ts` fail locally. I spent most of the unified 11 work describing those as environmental noise and repeating that in PR descriptions. They were this bug, and treating them as noise is what let the bad templates through.

## The fix

A worktree's metadata directory holds a `gitdir` file pointing at that worktree's `.git` file, whose parent is the top level we want.

One subtlety worth flagging for review: detecting a worktree requires comparing `worktreeGitDir` against `commonGitDir`, **not** checking `worktreeGitDir` for truthiness. It is always populated — outside a worktree it simply equals `commonGitDir`. My first pass got this wrong and would have taken the correction path always.

## Regression test

CI runs in a normal checkout, so this fix could regress invisibly there. The new test builds a real repository and worktree in a temp directory and asserts both resolve identically.

I verified it actually catches the bug rather than just passing:

| | with fix | without fix |
|---|---|---|
| edit url from the worktree | `…/edit/main/docs/{filepath}` | `…/edit/**linked**/docs/{filepath}` ❌ |
| edit url from the main checkout | `…/edit/main/docs/{filepath}` | `…/edit/main/docs/{filepath}` |

The second row matters as much as the first — it shows the fix doesn't alter normal-checkout behaviour.

The test uses `fs.realpathSync` on the temp dir because `os.tmpdir()` is a symlink on macOS and git records the resolved path; comparing against the unresolved one would fail there but pass on Linux.

## Result

`@docfy/core` now passes **59/59 across 12 files in a worktree**, where 6 tests in 3 files used to fail. And building `test-app-vite` from a worktree no longer rewrites the committed templates — removing the manual path-stripping step #215 needed three separate times.

Also verified: `pnpm -r run compile` clean, `@docfy/ember-vite` 60/60, `@docfy/plugin-with-prose` 2/2, both app builds succeed, lint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
