### PR TITLE
chore: upgrade remark-hbs to 0.5.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "prettier": "^3.5.3",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-katex": "^7.0.1",
-    "remark-hbs": "^0.4.1",
+    "remark-hbs": "^0.5.0",
     "remark-math": "^6.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",

--- a/packages/ember-cli/package.json
+++ b/packages/ember-cli/package.json
@@ -48,7 +48,7 @@
     "ember-cli-babel": "^8.2.0",
     "ember-cli-htmlbars": "^6.3.0",
     "mdast-util-to-string": "^4.0.0",
-    "remark-hbs": "^0.4.1",
+    "remark-hbs": "^0.5.0",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/ember-vite/package.json
+++ b/packages/ember-vite/package.json
@@ -45,7 +45,7 @@
     "debug": "^4.4.1",
     "fast-glob": "^3.2.0",
     "mdast-util-to-string": "^4.0.0",
-    "remark-hbs": "^0.4.1",
+    "remark-hbs": "^0.5.0",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1
       remark-hbs:
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0(unified@11.0.5)
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
@@ -283,8 +283,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       remark-hbs:
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0(unified@11.0.5)
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -464,8 +464,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       remark-hbs:
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: ^0.5.0
+        version: 0.5.0(unified@11.0.5)
       unist-util-visit:
         specifier: ^5.1.0
         version: 5.1.0
@@ -8605,9 +8605,11 @@ packages:
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
-  remark-hbs@0.4.1:
-    resolution: {integrity: sha512-q1qnjA473z409IGqj3iu0Rex9YVN3cfwf6siPP+SQN9Yx66OxyL2cU4VHWK6IxWHSa/cughU2CBUbDPPsWxlfg==}
-    engines: {node: '>= 10.*'}
+  remark-hbs@0.5.0:
+    resolution: {integrity: sha512-07JBlHcxpSL/fCbEnoqmZJXYSJQrw4bHbF1vl0sV6M4fpegh/v8m5iM9him6ZPq+JNMbZEIlVOa8XSLJSkA0yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      unified: ^11.0.0
 
   remark-math@6.0.0:
     resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
@@ -9785,9 +9787,6 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
-
-  unist-builder@2.0.3:
-    resolution: {integrity: sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw==}
 
   unist-util-find-after@5.0.0:
     resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
@@ -20506,10 +20505,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  remark-hbs@0.4.1:
+  remark-hbs@0.5.0(unified@11.0.5):
     dependencies:
-      unist-builder: 2.0.3
-      unist-util-visit: 2.0.3
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
 
   remark-math@6.0.0:
     dependencies:
@@ -22154,8 +22153,6 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
-
-  unist-builder@2.0.3: {}
 
   unist-util-find-after@5.0.0:
     dependencies:


### PR DESCRIPTION
Picks up [remark-hbs 0.5.0](https://github.com/josemarluedke/remark-hbs/releases/tag/v0.5.0), the ESM/unified 11 release. This removes the last stale link in Docfy's markdown pipeline — 0.4.1 was from 2021 and carried its own `unist-util-visit` 2 and `unist-builder` 2 alongside a tree running unified 11. 0.5.0 has `unist-util-visit` 5 as its only runtime dependency and takes `unified` 11 as a peer.

## No source changes needed

All three call sites already import the package root, which is all the new `exports` map permits:

```
packages/ember-cli/src/get-config.ts:4   import remarkHbs from 'remark-hbs';
packages/ember-cli/src/get-config.ts:9   import type { RemarkHbsOptions } from 'remark-hbs';
packages/ember-vite/src/config.ts:195    const remarkHbs = (await import('remark-hbs')).default;
```

The option names Docfy sets (`escapeCurliesCode`, `escapeCurliesInlineCode`) are unchanged, and `RemarkHbsOptions` is still importable — now as a named export rather than off a namespace, which is what the existing `import type` already expected.

## Things I checked rather than assumed

**The CJS interop path works.** `@docfy/ember-cli` compiles to CommonJS, so it does `require('remark-hbs').default` against an ESM-only package. The release notes say that works; confirmed:

```
keys: [ '__esModule', 'default' ] | typeof default: function
```

Worth recording how that nearly misled me: my first run returned `keys: [] | typeof default: undefined`, which looks exactly like broken interop. It was stale `node_modules` left by a baseline experiment I'd run minutes earlier — `Object.keys()` of 0.4.1's CJS function export. Reinstalling fixed it and the symlink now points at `remark-hbs@0.5.0_unified@11.0.5`. Had I trusted the first result I'd have filed a bug against a working package.

**The new `unified` peer needs no declaration.** `@docfy/ember-cli` and `@docfy/ember-vite` depend on remark-hbs without depending on `unified` directly, so I expected an unmet peer. pnpm satisfies it through `@docfy/core`, and `pnpm peers check` reports only the two pre-existing unrelated issues (`ember-source` via `ember-cli-fastboot-testing`, `tailwindcss` via `@tailwindcss/typography`).

**Rendered output is unchanged — verified, not trusted.** The release notes claim this, which is exactly the sort of claim worth testing independently. The committed `.gjs` templates are regenerated from `docs/` on every build, so if remark-hbs altered a single character they would move. They come out **byte-identical**: the templates guard passes with no diff.

That check is only usable from a worktree thanks to #218, which landed first.

## Verification

- `pnpm -r run compile` clean
- `@docfy/core` **59/59 across 12 files**, `@docfy/ember-vite` 60/60, `@docfy/plugin-with-prose` 2/2
- `test-app-classic` builds (the CJS/require-ESM path) with 19 distinct `hljs-*` classes including `hljs-template-variable`, so glimmer highlighting and curly escaping still work end to end
- `test-app-vite` builds; routes guard passes; templates guard passes with zero diff
- lint and `lint:format` clean

## Follow-up worth considering

remark-hbs declares `engines` of `^20.19.0 || >=22.12.0` while Docfy now requires `>=22.22.2`, and its CI matrix tests Node 20/22/24. That's harmless — Docfy's range is a subset — but if remark-hbs is only ever consumed by Docfy, its floor could eventually be raised to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
